### PR TITLE
Fix: Use default exports for humps library

### DIFF
--- a/src/sdk/v4/_fetcher.ts
+++ b/src/sdk/v4/_fetcher.ts
@@ -1,9 +1,11 @@
-import { camelizeKeys, decamelize, decamelizeKeys } from 'humps';
+import humps from 'humps';
 import { FetchFn } from '../../types';
 import { BaseApiOptions } from '../../types/BaseApiOptions';
 import { removeBeginningSlash } from '../../utils/misc';
 
 export const API_BASE_URL = 'https://api.quran.com/api/v4/';
+
+const { camelizeKeys, decamelize, decamelizeKeys } = humps;
 
 export const makeUrl = (url: string, params?: Record<string, unknown>) => {
   const baseUrl = `${API_BASE_URL}${removeBeginningSlash(url)}`;

--- a/src/sdk/v4/verses.ts
+++ b/src/sdk/v4/verses.ts
@@ -11,10 +11,12 @@ import {
   VerseKey,
   WordField,
 } from '../../types';
-import { decamelize } from 'humps';
+import humps from 'humps';
 import Utils from '../utils';
 import { fetcher, mergeApiOptions } from './_fetcher';
 import { BaseApiOptions } from '../../types/BaseApiOptions';
+
+const { decamelize } = humps;
 
 type GetVerseOptions = Partial<
   BaseApiOptions & {


### PR DESCRIPTION
# Issue

Currently, running in ESM mode is causing failures due to the way `humps` is imported and bundled by tsup. The humps library provides uses default exports to export it's functionality.

This becomes a problem for ESM bundling as `tsup` just includes the following line in the `index.min.mjs` bundle:
```javascript
import { camelizeKeys, decamelize, decamelizeKeys } from 'humps';
```
Running in ESM mode causes failures because named exports are not present in the humps module.

# Fix

Use default exports.

# Steps to reproduce

1. Initialise a simple ESM package locally.
2. Run `npm install @quranjs/api` to install the package.
3. Import the functionality and run the script. For example:

```javascript
import { quran } from "@quranjs/api";

const response = await quran.v4.audio.findChapterRecitationById(1);

console.log(response)

```

4. You should see the following error message: 

```
import { camelizeKeys, decamelize, decamelizeKeys } from 'humps';
         ^^^^^^^^^^^^
SyntaxError: Named export 'camelizeKeys' not found. The requested module 'humps' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'humps';
const { camelizeKeys, decamelize, decamelizeKeys } = pkg;

```

# Note on testing

I've tested this change using pnpm link to verify the changes. 

I've thought hard about including unit tests but vitest does transpilation of imported modules behind the scenes due to which this issue is hard to reproduce while testing. 

 