### PR TITLE
Feat: Add support for the text_indopak_nastaleeq field.

### DIFF
--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -313,6 +313,8 @@ export const handlers = [
               rub_number: 1,
               sajdah_type: null,
               sajdah_number: null,
+              text_indopak_nastaleeq:
+                'بِسْمِ اللّٰهِ الرَّحْمٰنِ الرَّحِیْمِ ۟',
               words: [
                 {
                   id: 1,

--- a/src/types/api/Verse.ts
+++ b/src/types/api/Verse.ts
@@ -21,6 +21,7 @@ export interface Verse {
   textImlaei?: string;
   textImlaeiSimple?: string;
   textIndopak?: string;
+  textIndopakNastaleeq?: string;
   sajdahNumber: null;
   // sajdahType: null;
   imageUrl?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,6 +90,7 @@ export type VerseField =
   | 'textImlaei'
   | 'textImlaeiSimple'
   | 'textIndopak'
+  | 'textIndopakNastaleeq'
   | 'textUthmaniTajweed'
   | 'imageUrl'
   | 'imageWidth'

--- a/test/verses.test.ts
+++ b/test/verses.test.ts
@@ -1,4 +1,6 @@
+import { expect, it, vi } from 'vitest';
 import { createApiTest } from './utils';
+import * as internalFetcher from '../src/sdk/v4/_fetcher';
 
 createApiTest('verses', {
   findByChapter: {
@@ -7,6 +9,32 @@ createApiTest('verses', {
     },
     params: ['1'],
     rejectParams: ['0' as any],
+    customCases: (method) => {
+      it('should return indopak_nastaleeq text', async () => {
+        const fetcherSpy = vi.spyOn(internalFetcher, 'fetcher');
+
+        const response = await method(1, {
+          fields: { textIndopakNastaleeq: true },
+        });
+
+        const expectedIndopakNastaleeqText =
+          'بِسْمِ اللّٰهِ الرَّحْمٰنِ الرَّحِیْمِ ۟';
+
+        expect(fetcherSpy).toHaveBeenCalledWith(
+          '/verses/by_chapter/1',
+          {
+            language: 'ar',
+            perPage: 50,
+            words: false,
+            fields: 'text_indopak_nastaleeq',
+          },
+          undefined
+        );
+        expect(response[0].textIndopakNastaleeq).toBe(
+          expectedIndopakNastaleeqText
+        );
+      });
+    },
   },
   findByJuz: {
     expect: {


### PR DESCRIPTION
# Problem

When using the `text_indopak` field the API doesn't return the surah ending characters correctly.

![image](https://github.com/user-attachments/assets/4f5c33f3-6414-4c17-8a87-fabc7358223a)

# Solution

Add support for the `text_indopak_nastaleeq` field that the API supports. This field, instead of the text_indopak, is useful when the using the nastaleeq font as it correctly provides each verse's end characters.

![image](https://github.com/user-attachments/assets/e7a3fc9a-49fb-4b54-958e-18604675c0c7)

# Note

I've not introduce `text_indopak_nastaleeq` for the `Word` fields type. Looking at the API, I think that's not supported (which makes complete sense) and hence, I've just added it for the text field.


