### PR TITLE
docs: align v2 guides with current sdk behavior

### DIFF
--- a/apps/docs/content/docs/audio.mdx
+++ b/apps/docs/content/docs/audio.mdx
@@ -18,8 +18,7 @@ console.log(recitations[0]);
 //   chapterId: 1,
 //   fileSize: 12345,
 //   format: "mp3",
-//   audioUrl: "https://audio.quran.com/...",
-//   duration: 120
+//   audioUrl: "https://audio.quran.com/..."
 // }
 ```
 
@@ -36,7 +35,7 @@ console.log(recitations[0]);
 const audio = await client.audio.findChapterRecitationById("2", "1");
 
 console.log(`URL: ${audio.audioUrl}`);
-console.log(`Duration: ${audio.duration}s`);
+console.log(`Format: ${audio.format}`);
 ```
 
 ## Verse Recitations
@@ -71,7 +70,7 @@ const { audioFiles } = await client.audio.findVerseRecitationsByKey(
 
 const audio = audioFiles[0];
 console.log(`URL: ${audio.url}`);
-console.log(`Duration: ${audio.duration}s`);
+console.log(`Format: ${audio.format ?? "stream"}`);
 ```
 
 ## Field Selection
@@ -79,10 +78,12 @@ console.log(`Duration: ${audio.duration}s`);
 ```ts
 const { audioFiles } = await client.audio.findVerseRecitationsByChapter("1", "2", {
   fields: {
-    url: true,
-    duration: true,
     segments: true,
-    format: false,
+    format: true,
+    id: true,
+    chapterId: false,
   },
 });
+
+// Available verse fields: id, chapterId, segments, format
 ```

--- a/apps/docs/content/docs/resources.mdx
+++ b/apps/docs/content/docs/resources.mdx
@@ -13,7 +13,7 @@ The Resources API provides metadata about translations, tafsirs, reciters, and o
 const recitations = await client.resources.findAllRecitations();
 
 recitations.forEach((r) => {
-  console.log(`${r.id}. ${r.reciterName} (${r.style})`);
+  console.log(`${r.id}. ${r.reciterName ?? "Unknown"} (${r.style ?? "N/A"})`);
 });
 ```
 
@@ -29,9 +29,7 @@ recitations.forEach((r) => {
 ```ts
 const info = await client.resources.findRecitationInfo("2");
 
-console.log(info.reciterName);
-console.log(info.bio);
-console.log(info.photo);
+console.log(info.info); // Rich text/HTML describing the recitation
 ```
 
 ### RecitationInfoResource Type
@@ -64,10 +62,7 @@ const urdu = translations.filter((t) => t.languageName === "urdu");
 ```ts
 const info = await client.resources.findTranslationInfo("131");
 
-console.log(info.name);
-console.log(info.authorName);
-console.log(info.languageName);
-console.log(info.bio);
+console.log(info.info); // Information about the translation (HTML/string)
 ```
 
 ### TranslationInfoResource Type
@@ -101,9 +96,7 @@ tafsirs.forEach((t) => {
 ```ts
 const info = await client.resources.findTafsirInfo("171");
 
-console.log(info.name);       // "Tafsir Ibn Kathir"
-console.log(info.authorName); // "Ibn Kathir"
-console.log(info.bio);
+console.log(info.info); // Tafsir description/content
 ```
 
 ### TafsirInfoResource Type
@@ -119,7 +112,7 @@ console.log(info.bio);
 const languages = await client.resources.findAllLanguages();
 
 languages.forEach((lang) => {
-  console.log(`${lang.name} (${lang.iso}): ${lang.translationsCount} translations`);
+  console.log(`${lang.name} (${lang.isoCode}) - native: ${lang.nativeName}`);
 });
 ```
 
@@ -155,7 +148,7 @@ chapterInfos.forEach((info) => {
 const reciters = await client.resources.findAllChapterReciters();
 
 reciters.forEach((r) => {
-  console.log(`${r.name} (${r.arabicName})`);
+  console.log(`${r.name} (${r.arabicName ?? "n/a"})`);
 });
 ```
 
@@ -187,9 +180,8 @@ console.log(styles.mujawwad);  // Mujawwad reciters
 ```ts
 const media = await client.resources.findVerseMedia();
 
-console.log(media.unicode); // Font URL
-console.log(media.image);   // Images base URL
-console.log(media.audio);   // Audio base URL
+console.log(media.name);        // Resource name
+console.log(media.languageName); // Language of the resource
 ```
 
 ### VerseMediaResource Type

--- a/apps/docs/content/docs/search.mdx
+++ b/apps/docs/content/docs/search.mdx
@@ -12,8 +12,8 @@ const results = await client.search.search("light");
 
 console.log(`Found ${results.totalResults} results`);
 
-results.results.forEach((result) => {
-  console.log(`${result.verseKey}: ${result.highlightedText}`);
+(results.results ?? []).forEach((result) => {
+  console.log(`${result.verseKey}: ${result.highlighted ?? result.text}`);
 });
 ```
 

--- a/apps/docs/content/docs/v1-migration-guide.mdx
+++ b/apps/docs/content/docs/v1-migration-guide.mdx
@@ -104,14 +104,7 @@ client.updateConfig({
 
 ## Backward Compatibility
 
-The old `quran.v4` API is still available for backward compatibility but is deprecated:
-
-```javascript
-import { quran } from "@quranjs/api";
-
-// Still works but deprecated
-const chapters = await quran.v4.chapters.findAll();
-```
+The legacy `quran.v4` namespace that was exported in v1 has been removed in v2. Upgrading projects must create a `QuranClient` instance (as shown above) and supply a client ID and secret. Any code that still imports `quran.v4` will throw at runtime after upgrading, so plan your migration before bumping to v2.
 
 ## Error Handling
 

--- a/apps/docs/content/docs/verses.mdx
+++ b/apps/docs/content/docs/verses.mdx
@@ -27,9 +27,9 @@ const verse = await client.verses.findByKey("2:255", {
   translations: [20, 131], // English and Urdu
   words: true,
   translationFields: {
-    text: true,
     languageName: true,
     resourceName: true,
+    verseKey: true,
   },
 });
 ```
@@ -105,9 +105,8 @@ const verse = await client.verses.findByKey("1:1", {
   words: true,
   wordFields: {
     textUthmani: true,
-    transliteration: true,
-    translation: true,
-    audio: true,
+    verseKey: true,
+    location: true,
   },
 });
 ```
@@ -118,9 +117,9 @@ const verse = await client.verses.findByKey("1:1", {
 const verse = await client.verses.findByKey("2:255", {
   translations: [20, 131],
   translationFields: {
-    text: true,
     languageName: true,
     resourceName: true,
+    verseKey: true,
   },
 });
 ```
@@ -132,8 +131,8 @@ const verse = await client.verses.findByKey("1:1", {
   fields: {
     textUthmani: true,
     textUthmaniTajweed: true,
-    pageNumber: true,
-    juzNumber: true,
+    codeV1: true,
+    v1Page: true,
   },
 });
 ```


### PR DESCRIPTION
* remove the outdated quran.v4 fallback from the migration guide and call out the requirement to instantiate QuranClient with credentials
* refresh audio, resources, search, and verses examples to match live typings (correct field names, supported options, and returned properties)
* tidy field-selection snippets and guard search results iteration so docs mirror real-world responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API response examples across audio, resources, verses, and search documentation to reflect current field structure.
  * Updated field selection examples with new available fields, including format and location options.
  * Clarified v2 migration requirements with updated guidance on authentication setup.
  * Added graceful handling of missing values in code examples for recitations, translations, and tafsirs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->