### PR TITLE
Align SDK search API with v1 search service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ dist
 env.d.ts
 next-env.d.ts
 **/.vscode
+
+.env

--- a/packages/api/mocks/handlers.ts
+++ b/packages/api/mocks/handlers.ts
@@ -101,17 +101,34 @@ export const handlers = [
     },
   ),
 
-  http.get(
-    "https://apis.quran.foundation/content/api/v4/search",
-    ({ request }) => {
-      try {
-        validateAuth(request);
-        return HttpResponse.json({});
-      } catch {
-        return HttpResponse.text("Unauthorized", { status: 401 });
-      }
-    },
-  ),
+  http.get("https://apis.quran.foundation/v1/search", ({ request }) => {
+    try {
+      validateAuth(request);
+      return HttpResponse.json({
+        result: {
+          navigation: [
+            {
+              result_type: "surah",
+              key: "1",
+              name: "Al-Fatihah",
+              arabic: "الفاتحة",
+              isArabic: true,
+            },
+          ],
+          verses: [],
+        },
+        pagination: {
+          current_page: 1,
+          next_page: null,
+          per_page: 30,
+          total_pages: 1,
+          total_records: 1,
+        },
+      });
+    } catch {
+      return HttpResponse.text("Unauthorized", { status: 401 });
+    }
+  }),
 
   http.get(
     "https://apis.quran.foundation/content/api/v4/resources/recitations",

--- a/packages/api/src/lib/url.ts
+++ b/packages/api/src/lib/url.ts
@@ -1,41 +1,48 @@
 import type { ApiParams } from "@/types";
 import humps from "humps";
 
-const { decamelize, decamelizeKeys } = humps;
+const { decamelize } = humps;
 
 export const removeBeginningSlash = (url: string) => {
   return url.startsWith("/") ? url.slice(1) : url;
 };
 
-const fieldsKey = ["wordFields", "translationFields", "fields"];
+const fieldsKey = ["wordFields", "translationFields", "fields"] as const;
+const fieldsKeySet = new Set<string>([
+  ...fieldsKey,
+  ...fieldsKey.map((key) => decamelize(key)),
+]);
+const preservedKeys = new Set(["navigationalResultsNumber", "versesResultsNumber"]);
 
 export const paramsToString = (params?: ApiParams): string => {
   if (!params) return "";
 
-  const paramsWithDecamelizedKeys = decamelizeKeys(params) as ApiParams;
   const paramsString = new URLSearchParams();
 
-  for (const [key, value] of Object.entries(paramsWithDecamelizedKeys)) {
-    if (value === undefined) continue;
+  for (const [rawKey, rawValue] of Object.entries(params)) {
+    if (rawValue === undefined) continue;
 
-    if (typeof value === "string") {
-      paramsString.set(key, value);
-    } else if (typeof value === "number") {
-      paramsString.set(key, value.toString());
-    } else if (typeof value === "boolean") {
-      paramsString.set(key, value.toString());
-    } else if (Array.isArray(value)) {
-      paramsString.set(key, value.join(","));
-    }
+    const key = preservedKeys.has(rawKey) ? rawKey : decamelize(rawKey);
 
     // fields is a special case, it's an object with boolean values
-    if (fieldsKey.includes(key)) {
-      const fields = Object.entries(value)
+    if (fieldsKeySet.has(rawKey) || fieldsKeySet.has(key)) {
+      const fields = Object.entries(rawValue as Record<string, boolean>)
         .filter(([, value]) => value)
-        .map(([key]) => decamelize(key));
+        .map(([fieldKey]) => decamelize(fieldKey));
       if (fields.length > 0) {
         paramsString.set(key, fields.join(","));
       }
+      continue;
+    }
+
+    if (typeof rawValue === "string") {
+      paramsString.set(key, rawValue);
+    } else if (typeof rawValue === "number") {
+      paramsString.set(key, rawValue.toString());
+    } else if (typeof rawValue === "boolean") {
+      paramsString.set(key, rawValue.toString());
+    } else if (Array.isArray(rawValue)) {
+      paramsString.set(key, rawValue.join(","));
     }
   }
 

--- a/packages/api/src/sdk/search.ts
+++ b/packages/api/src/sdk/search.ts
@@ -2,7 +2,7 @@ import type { SearchParams, SearchResponse } from "@/types";
 
 import type { QuranFetcher } from "./fetcher";
 
-type SearchOptions = SearchParams;
+type SearchOptions = Omit<SearchParams, "query">;
 
 /**
  * Search API methods
@@ -12,28 +12,20 @@ export class QuranSearch {
 
   /**
    * Search
-   * @description https://api-docs.quran.com/docs/quran.com_versioned/4.0.0/search
-   * @param {string} q search query
+   * @description /v1/search
+   * @param {string} query search query
    * @param {SearchOptions} options
    * @example
-   * client.search.search('نور')
-   * client.search.search('نور', { language: Language.ENGLISH })
-   * client.search.search('نور', { language: Language.ENGLISH, size: 10 })
-   * client.search.search('نور', { language: Language.ENGLISH, page: 2 })
+   * client.search.search('نور', { mode: SearchMode.Quick })
+   * client.search.search('نور', { mode: SearchMode.Advanced, exactMatchesOnly: '1' })
+   * client.search.search('نور', { mode: SearchMode.Quick, size: 10 })
+   * client.search.search('نور', { mode: SearchMode.Quick, page: 2 })
    */
-  async search(
-    q: string,
-    options?: SearchOptions,
-  ): Promise<SearchResponse["search"]> {
-    const { search } = await this.fetcher.fetch<SearchResponse>(
-      "/content/api/v4/search",
-      {
-        q,
-        size: 30, // search-specific default
-        ...options,
-      },
-    );
-
-    return search;
+  async search(query: string, options: SearchOptions): Promise<SearchResponse> {
+    return this.fetcher.fetch<SearchResponse>("/v1/search", {
+      query,
+      size: 30, // search-specific default
+      ...options,
+    });
   }
 }

--- a/packages/api/src/types/BaseApiParams.ts
+++ b/packages/api/src/types/BaseApiParams.ts
@@ -1,4 +1,9 @@
-import type { Language } from ".";
+import type {
+  Language,
+  TranslationField,
+  VerseField,
+  WordField,
+} from ".";
 
 export type ApiParams = Record<
   string,
@@ -23,12 +28,47 @@ export interface PaginationParams extends ApiParams {
   perPage?: number;
 }
 
+export type BinaryString = "0" | "1";
+
+export enum SearchMode {
+  Advanced = "advanced",
+  Quick = "quick",
+}
+
 /**
  * Search parameters
  */
 export interface SearchParams extends BaseApiParams {
-  /** Number of results to return */
-  size?: number;
+  /** Search mode */
+  mode: SearchMode;
+  /** Search query */
+  query: string;
+  /** Filter translations */
+  filterTranslations?: string | string[];
+  /** For advanced search, limit to exact matches */
+  exactMatchesOnly?: BinaryString;
+  /** Include text in the response */
+  getText?: BinaryString;
+  /** Include highlighted text */
+  highlight?: BinaryString;
+  /** Quick search navigational results count */
+  navigationalResultsNumber?: number;
+  /** Quick search verse results count */
+  versesResultsNumber?: number;
+  /** Comma-separated list of indexes */
+  indexes?: string | string[];
   /** Page number for pagination */
   page?: number;
+  /** Number of results to return */
+  size?: number;
+  /** Translation IDs to use for language detection */
+  translationIds?: string | number | Array<string | number>;
+  /** Quran fields to include in verse filters */
+  fields?: Partial<Record<VerseField, boolean>>;
+  /** Translation fields to include in verse filters */
+  translationFields?: Partial<Record<TranslationField, boolean>>;
+  /** Word fields to include in verse filters */
+  wordFields?: Partial<Record<WordField, boolean>>;
+  /** Include word data in verse filters */
+  words?: boolean;
 }

--- a/packages/api/src/types/api/ApiResponses.ts
+++ b/packages/api/src/types/api/ApiResponses.ts
@@ -1,19 +1,15 @@
-import type { Translation } from "./Translation";
-import type { Word } from "./Word";
+import type { SearchResult } from "./search-result";
 
 export interface SearchResponse {
-  search: {
-    query: string;
-    totalResults: number;
+  pagination: {
     currentPage: number;
+    nextPage: number | null;
+    perPage: number;
     totalPages: number;
-    results?: {
-      verseKey: string;
-      verse_id: number;
-      text: string;
-      highlighted: string;
-      words: Word[];
-      translations: Translation[];
-    }[];
+    totalRecords: number;
+  };
+  result?: {
+    navigation: SearchResult[];
+    verses: SearchResult[];
   };
 }

--- a/packages/api/src/types/api/search-result.ts
+++ b/packages/api/src/types/api/search-result.ts
@@ -1,12 +1,20 @@
-import type { VerseKey } from "../common/verse-key";
-import type { Translation } from "./Translation";
-import type { Word } from "./Word";
+export enum SearchNavigationType {
+  SURAH = "surah",
+  JUZ = "juz",
+  HIZB = "hizb",
+  AYAH = "ayah",
+  RUB_EL_HIZB = "rub_el_hizb",
+  SEARCH_PAGE = "search_page",
+  PAGE = "page",
+  RANGE = "range",
+  QURAN_RANGE = "quran_range",
+}
 
 export interface SearchResult {
-  verseKey: VerseKey;
-  verseId: number;
-  text: string;
-  highlighted?: string;
-  words: Word[];
-  translations: Translation[];
+  resultType: SearchNavigationType;
+  key: number | string;
+  name: string;
+  arabic?: string;
+  isArabic?: boolean;
+  isTransliteration?: boolean;
 }

--- a/packages/api/test/search.test.ts
+++ b/packages/api/test/search.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+
+import { SearchMode } from "../src";
+import { server } from "../mocks/server";
+import { testClient } from "./test-client";
+
+const SEARCH_URL = "https://apis.quran.foundation/v1/search";
+
+const baseResponse = {
+  result: {
+    navigation: [],
+    verses: [],
+  },
+  pagination: {
+    current_page: 1,
+    next_page: null,
+    per_page: 30,
+    total_pages: 1,
+    total_records: 0,
+  },
+};
+
+describe("Search API", () => {
+  it("camelizes the response payload", async () => {
+    server.use(
+      http.get(SEARCH_URL, () => {
+        return HttpResponse.json({
+          result: {
+            navigation: [
+              {
+                result_type: "surah",
+                key: "1",
+                name: "Al-Fatihah",
+              },
+            ],
+            verses: [],
+          },
+          pagination: {
+            current_page: 1,
+            next_page: null,
+            per_page: 30,
+            total_pages: 1,
+            total_records: 1,
+          },
+        });
+      }),
+    );
+
+    const response = await testClient.search.search("test", {
+      mode: SearchMode.Quick,
+    });
+
+    expect(response.pagination.currentPage).toBe(1);
+    expect(response.pagination.nextPage).toBeNull();
+    expect(response.result?.navigation[0].resultType).toBe("surah");
+  });
+
+  it("sends query, mode, and default size", async () => {
+    let requestUrl: URL | null = null;
+    server.use(
+      http.get(SEARCH_URL, ({ request }) => {
+        requestUrl = new URL(request.url);
+        return HttpResponse.json(baseResponse);
+      }),
+    );
+
+    await testClient.search.search("test", { mode: SearchMode.Quick });
+
+    expect(requestUrl).not.toBeNull();
+    const params = requestUrl?.searchParams;
+    expect(params?.get("query")).toBe("test");
+    expect(params?.get("mode")).toBe("quick");
+    expect(params?.get("size")).toBe("30");
+  });
+
+  it("serializes advanced search params", async () => {
+    let requestUrl: URL | null = null;
+    server.use(
+      http.get(SEARCH_URL, ({ request }) => {
+        requestUrl = new URL(request.url);
+        return HttpResponse.json(baseResponse);
+      }),
+    );
+
+    await testClient.search.search("test", {
+      mode: SearchMode.Advanced,
+      exactMatchesOnly: "1",
+      getText: "1",
+      highlight: "0",
+      page: 2,
+      size: 12,
+    });
+
+    const params = requestUrl?.searchParams;
+    expect(params?.get("exact_matches_only")).toBe("1");
+    expect(params?.get("get_text")).toBe("1");
+    expect(params?.get("highlight")).toBe("0");
+    expect(params?.get("page")).toBe("2");
+    expect(params?.get("size")).toBe("12");
+  });
+
+  it("preserves quick search result keys without decamelizing", async () => {
+    let requestUrl: URL | null = null;
+    server.use(
+      http.get(SEARCH_URL, ({ request }) => {
+        requestUrl = new URL(request.url);
+        return HttpResponse.json(baseResponse);
+      }),
+    );
+
+    await testClient.search.search("test", {
+      mode: SearchMode.Quick,
+      navigationalResultsNumber: 7,
+      versesResultsNumber: 9,
+    });
+
+    const params = requestUrl?.searchParams;
+    expect(params?.get("navigationalResultsNumber")).toBe("7");
+    expect(params?.get("versesResultsNumber")).toBe("9");
+    expect(params?.has("navigational_results_number")).toBe(false);
+    expect(params?.has("verses_results_number")).toBe(false);
+  });
+
+  it("serializes arrays, booleans, and field selections", async () => {
+    let requestUrl: URL | null = null;
+    server.use(
+      http.get(SEARCH_URL, ({ request }) => {
+        requestUrl = new URL(request.url);
+        return HttpResponse.json(baseResponse);
+      }),
+    );
+
+    await testClient.search.search("test", {
+      mode: SearchMode.Quick,
+      translationIds: [131, 20],
+      filterTranslations: ["en", "ar"],
+      indexes: ["verses", "chapters"],
+      words: true,
+      fields: {
+        textUthmani: true,
+        codeV2: false,
+      },
+      wordFields: {
+        verseKey: true,
+        location: true,
+      },
+      translationFields: {
+        resourceName: true,
+        languageName: true,
+      },
+    });
+
+    const params = requestUrl?.searchParams;
+    expect(params?.get("translation_ids")).toBe("131,20");
+    expect(params?.get("filter_translations")).toBe("en,ar");
+    expect(params?.get("indexes")).toBe("verses,chapters");
+    expect(params?.get("words")).toBe("true");
+
+    const fields = params?.get("fields")?.split(",") ?? [];
+    expect(fields).toContain("text_uthmani");
+    expect(fields).not.toContain("code_v2");
+
+    const wordFields = params?.get("word_fields")?.split(",") ?? [];
+    expect(wordFields).toContain("verse_key");
+    expect(wordFields).toContain("location");
+
+    const translationFields =
+      params?.get("translation_fields")?.split(",") ?? [];
+    expect(translationFields).toContain("resource_name");
+    expect(translationFields).toContain("language_name");
+  });
+});


### PR DESCRIPTION
## Summary
- Switch search client to /v1/search and update response typing
- Expand search params for quick/advanced modes and field options
- Fix query serialization for quick-search keys and fields
- Update MSW mock and add search SDK tests
- Ignore .env locally

## Testing
- pnpm -C E:\api-js\packages\api test -- --run test/search.test.ts
