### PR TITLE
Fix chapter recitation endpoints in SDK

### DIFF
--- a/packages/api/mocks/handlers.ts
+++ b/packages/api/mocks/handlers.ts
@@ -154,21 +154,21 @@ export const handlers = [
     },
   ),
 
-  // Audio endpoints for recitations
+  // Audio endpoints for chapter recitations
   http.get(
-    "https://apis.quran.foundation/content/api/v4/recitations/:reciterId",
+    "https://apis.quran.foundation/content/api/v4/chapter_recitations/:id",
     ({ request, params }) => {
       try {
         validateAuth(request);
         return HttpResponse.json({
-          audioFiles: [
+          audio_files: [
             {
               id: 1,
               chapter_id: 1,
               file_size: 123456,
               format: "mp3",
               total_files: 114,
-              recitation_id: params.reciterId,
+              recitation_id: params.id,
             },
           ],
         });
@@ -179,17 +179,17 @@ export const handlers = [
   ),
 
   http.get(
-    "https://apis.quran.foundation/content/api/v4/recitations/:reciterId/:chapterId",
+    "https://apis.quran.foundation/content/api/v4/chapter_recitations/:id/:chapter_number",
     ({ request, params }) => {
       try {
         validateAuth(request);
         return HttpResponse.json({
-          audioFile: {
+          audio_file: {
             id: 1,
-            chapter_id: params.chapterId,
+            chapter_id: params.chapter_number,
             file_size: 123456,
             format: "mp3",
-            recitation_id: params.reciterId,
+            recitation_id: params.id,
           },
         });
       } catch {
@@ -401,23 +401,6 @@ export const handlers = [
     () => {
       return HttpResponse.json({
         verses: [{ id: 1, verse_key: "1:1", code_v2: " ﱂ ﱃ ﱄ ﱅ", v2_page: 1 }],
-      });
-    },
-  ),
-
-  http.get(
-    "https://apis.quran.foundation/chapter_recitations/:id/:chapter_number",
-    () => {
-      return HttpResponse.json({
-        audio_file: {
-          id: 43,
-          chapter_id: 22,
-          file_size: 19779712,
-          format: "mp3",
-          total_files: 1,
-          audio_url:
-            "https://download.quranicaudio.com/quran/abdullaah_3awwaad_al-juhaynee/022.mp3",
-        },
       });
     },
   ),
@@ -1485,31 +1468,6 @@ export const handlers = [
       });
     },
   ),
-
-  http.get("https://apis.quran.foundation/chapter_recitations/:id", () => {
-    return HttpResponse.json({
-      audio_files: [
-        {
-          id: 43,
-          chapter_id: 22,
-          file_size: 19779712,
-          format: "mp3",
-          total_files: 1,
-          audio_url:
-            "https://download.quranicaudio.com/quran/abdullaah_3awwaad_al-juhaynee//022.mp3",
-        },
-        {
-          id: 87,
-          chapter_id: 44,
-          file_size: 6453376,
-          format: "mp3",
-          total_files: 1,
-          audio_url:
-            "https://download.quranicaudio.com/quran/abdullaah_3awwaad_al-juhaynee//044.mp3",
-        },
-      ],
-    });
-  }),
 
   http.get(
     "https://apis.quran.foundation/content/api/v4/recitations/:recitation_id/by_chapter/:chapter_number",

--- a/packages/api/src/sdk/audio.ts
+++ b/packages/api/src/sdk/audio.ts
@@ -36,7 +36,7 @@ export class QuranAudio {
   ): Promise<ChapterRecitation[]> {
     const { audioFiles } = await this.fetcher.fetch<{
       audioFiles: ChapterRecitation[];
-    }>(`/content/api/v4/recitations/${reciterId}`, options);
+    }>(`/content/api/v4/chapter_recitations/${reciterId}`, options);
 
     return audioFiles;
   }
@@ -58,7 +58,7 @@ export class QuranAudio {
 
     const { audioFile } = await this.fetcher.fetch<{
       audioFile: ChapterRecitation;
-    }>(`/content/api/v4/recitations/${reciterId}/${chapterId}`, options);
+    }>(`/content/api/v4/chapter_recitations/${reciterId}/${chapterId}`, options);
 
     return audioFile;
   }

--- a/packages/api/test/audio.test.ts
+++ b/packages/api/test/audio.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { testClient } from "./test-client";
 
@@ -16,6 +16,26 @@ describe("Audio API", () => {
       expect(response).toBeInstanceOf(Array);
       expect(response).toBeDefined();
     });
+
+    it("should call chapter_recitations endpoint", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      try {
+        await testClient.audio.findAllChapterRecitations(VALID_RECITATION_ID);
+        const contentCall = fetchSpy.mock.calls
+          .map((call) => call[0])
+          .find(
+            (url) =>
+              typeof url === "string" && url.includes("/content/api/v4/"),
+          );
+        expect(contentCall).toBeDefined();
+        const contentUrl = new URL(contentCall as string);
+        expect(contentUrl.pathname).toBe(
+          `/content/api/v4/chapter_recitations/${VALID_RECITATION_ID}`,
+        );
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
   });
 
   describe("findChapterRecitationById()", () => {
@@ -25,6 +45,29 @@ describe("Audio API", () => {
         VALID_CHAPTER_ID,
       );
       expect(response).toBeDefined();
+    });
+
+    it("should call chapter_recitations endpoint with chapter id", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      try {
+        await testClient.audio.findChapterRecitationById(
+          VALID_RECITATION_ID,
+          VALID_CHAPTER_ID,
+        );
+        const contentCall = fetchSpy.mock.calls
+          .map((call) => call[0])
+          .find(
+            (url) =>
+              typeof url === "string" && url.includes("/content/api/v4/"),
+          );
+        expect(contentCall).toBeDefined();
+        const contentUrl = new URL(contentCall as string);
+        expect(contentUrl.pathname).toBe(
+          `/content/api/v4/chapter_recitations/${VALID_RECITATION_ID}/${VALID_CHAPTER_ID}`,
+        );
+      } finally {
+        fetchSpy.mockRestore();
+      }
     });
 
     it("should throw error for invalid chapter ID", async () => {


### PR DESCRIPTION
Summary:
- switch chapter audio calls to /content/api/v4/chapter_recitations
- update MSW handlers to match the new endpoints
- add URL assertions in audio tests to prevent regressions

Testing:
- npx pnpm -C packages/api test

Closes #38 
