### PR TITLE
fix(audio): verse recitation URLs should return absolute paths, not relative

### DIFF
--- a/.changeset/late-cycles-hear.md
+++ b/.changeset/late-cycles-hear.md
@@ -1,0 +1,5 @@
+---
+"@quranjs/api": patch
+---
+
+Add absolute audioUrl values to verse recitation responses.

--- a/packages/api/mocks/handlers.ts
+++ b/packages/api/mocks/handlers.ts
@@ -47,27 +47,22 @@ export const handlers = [
 
   http.get(
     "https://apis.quran.foundation/content/api/v4/verses/by_range",
-    ({ request }) => {
-      try {
-        validateAuth(request);
-        return HttpResponse.json({
-          verses: [
-            {
-              id: 1,
-              verse_number: 1,
-              page_number: 1,
-              verse_key: "1:1",
-              juz_number: 1,
-              hizb_number: 1,
-              rub_number: 1,
-              sajdah_type: null,
-              sajdah_number: null,
-            },
-          ],
-        });
-      } catch {
-        return HttpResponse.text("Unauthorized", { status: 401 });
-      }
+    () => {
+      return HttpResponse.json({
+        verses: [
+          {
+            id: 1,
+            verse_number: 1,
+            page_number: 1,
+            verse_key: "1:1",
+            juz_number: 1,
+            hizb_number: 1,
+            rub_number: 1,
+            sajdah_type: null,
+            sajdah_number: null,
+          },
+        ],
+      });
     },
   ),
 

--- a/packages/api/mocks/handlers.ts
+++ b/packages/api/mocks/handlers.ts
@@ -209,6 +209,7 @@ export const handlers = [
               id: 1,
               chapter_id: params.chapterId,
               verse_key: "1:1",
+              url: "AbdulBaset/Murattal/mp3/001001.mp3",
               file_size: 123456,
               format: "mp3",
               recitation_id: params.recitationId,
@@ -238,6 +239,7 @@ export const handlers = [
             {
               id: 1,
               verse_key: params.key,
+              url: "AbdulBaset/Murattal/mp3/002255.mp3",
               file_size: 123456,
               format: "mp3",
               recitation_id: params.recitationId,

--- a/packages/api/mocks/handlers.ts
+++ b/packages/api/mocks/handlers.ts
@@ -234,20 +234,25 @@ export const handlers = [
     ({ request, params }) => {
       try {
         validateAuth(request);
+        const verseKey = String(params.key);
+        const [chapter, verse] = verseKey.split(":");
+        const relativeUrl = `AbdulBaset/Murattal/mp3/${chapter.padStart(3, "0")}${verse.padStart(3, "0")}.mp3`;
+        const absoluteUrl = `https://verses.quran.com/${relativeUrl}`;
+
         return HttpResponse.json({
           audioFiles: [
             {
               id: 1,
-              verse_key: params.key,
-              url: "AbdulBaset/Murattal/mp3/002255.mp3",
+              verse_key: verseKey,
+              url: relativeUrl,
               file_size: 123456,
               format: "mp3",
               recitation_id: params.recitationId,
             },
             {
               id: 2,
-              verse_key: params.key,
-              url: "https://verses.quran.com/AbdulBaset/Murattal/mp3/002255.mp3",
+              verse_key: verseKey,
+              url: absoluteUrl,
               file_size: 123456,
               format: "mp3",
               recitation_id: params.recitationId,

--- a/packages/api/mocks/handlers.ts
+++ b/packages/api/mocks/handlers.ts
@@ -244,13 +244,21 @@ export const handlers = [
               format: "mp3",
               recitation_id: params.recitationId,
             },
+            {
+              id: 2,
+              verse_key: params.key,
+              url: "https://verses.quran.com/AbdulBaset/Murattal/mp3/002255.mp3",
+              file_size: 123456,
+              format: "mp3",
+              recitation_id: params.recitationId,
+            },
           ],
           pagination: {
             per_page: 50,
             current_page: 1,
             next_page: null,
             total_pages: 1,
-            total_records: 1,
+            total_records: 2,
           },
         });
       } catch {

--- a/packages/api/src/sdk/audio.ts
+++ b/packages/api/src/sdk/audio.ts
@@ -18,6 +18,33 @@ type GetVerseRecitationOptions = BaseApiParams & {
 };
 
 /**
+ * Base URL for verse audio files from Quran.com
+ * Used to convert relative paths to absolute URLs
+ */
+const AUDIO_BASE_URL = "https://verses.quran.com";
+
+/**
+ * Normalize verse recitation data by adding absolute audioUrl
+ * The API returns relative paths in the 'url' field, but we want
+ * to provide absolute URLs for consistency with chapter recitations
+ */
+function normalizeVerseRecitations(
+  audioFiles: VerseRecitation[],
+): VerseRecitation[] {
+  return audioFiles.map((file) => {
+    // If url is already absolute, use it; otherwise prepend the base URL
+    const absoluteUrl = file.url.startsWith("http")
+      ? file.url
+      : `${AUDIO_BASE_URL}/${file.url}`;
+
+    return {
+      ...file,
+      audioUrl: absoluteUrl,
+    };
+  });
+}
+
+/**
  * Audio API methods
  */
 export class QuranAudio {
@@ -86,7 +113,10 @@ export class QuranAudio {
       options,
     );
 
-    return data;
+    return {
+      ...data,
+      audioFiles: normalizeVerseRecitations(data.audioFiles),
+    };
   }
 
   /**
@@ -109,6 +139,9 @@ export class QuranAudio {
       pagination: Pagination;
     }>(`/content/api/v4/recitations/${recitationId}/by_ayah/${key}`, options);
 
-    return data;
+    return {
+      ...data,
+      audioFiles: normalizeVerseRecitations(data.audioFiles),
+    };
   }
 }

--- a/packages/api/src/sdk/audio.ts
+++ b/packages/api/src/sdk/audio.ts
@@ -17,6 +17,8 @@ type GetVerseRecitationOptions = BaseApiParams & {
   fields?: Partial<Record<VerseRecitationField, boolean>>;
 };
 
+type RawVerseRecitation = Omit<VerseRecitation, "audioUrl">;
+
 /**
  * Base URL for verse audio files from Quran.com
  * Used to convert relative paths to absolute URLs
@@ -29,13 +31,14 @@ const AUDIO_BASE_URL = "https://verses.quran.com";
  * to provide absolute URLs for consistency with chapter recitations
  */
 function normalizeVerseRecitations(
-  audioFiles: VerseRecitation[],
+  audioFiles: RawVerseRecitation[],
 ): VerseRecitation[] {
   return audioFiles.map((file) => {
     // If url is already absolute, use it; otherwise prepend the base URL
-    const absoluteUrl = file.url.startsWith("http")
-      ? file.url
-      : `${AUDIO_BASE_URL}/${file.url}`;
+    const absoluteUrl =
+      file.url.startsWith("http://") || file.url.startsWith("https://")
+        ? file.url
+        : `${AUDIO_BASE_URL}/${file.url.replace(/^\/+/, "")}`;
 
     return {
       ...file,
@@ -85,7 +88,10 @@ export class QuranAudio {
 
     const { audioFile } = await this.fetcher.fetch<{
       audioFile: ChapterRecitation;
-    }>(`/content/api/v4/chapter_recitations/${reciterId}/${chapterId}`, options);
+    }>(
+      `/content/api/v4/chapter_recitations/${reciterId}/${chapterId}`,
+      options,
+    );
 
     return audioFile;
   }
@@ -106,7 +112,7 @@ export class QuranAudio {
     if (!isValidChapterId(chapterId)) throw new Error("Invalid chapter id");
 
     const data = await this.fetcher.fetch<{
-      audioFiles: VerseRecitation[];
+      audioFiles: RawVerseRecitation[];
       pagination: Pagination;
     }>(
       `/content/api/v4/recitations/${recitationId}/by_chapter/${chapterId}`,
@@ -135,7 +141,7 @@ export class QuranAudio {
     if (!isValidVerseKey(key)) throw new Error("Invalid verse key");
 
     const data = await this.fetcher.fetch<{
-      audioFiles: VerseRecitation[];
+      audioFiles: RawVerseRecitation[];
       pagination: Pagination;
     }>(`/content/api/v4/recitations/${recitationId}/by_ayah/${key}`, options);
 

--- a/packages/api/src/sdk/audio.ts
+++ b/packages/api/src/sdk/audio.ts
@@ -2,6 +2,7 @@ import type {
   BaseApiParams,
   ChapterId,
   ChapterRecitation,
+  NormalizedVerseRecitation,
   Pagination,
   VerseKey,
   VerseRecitation,
@@ -32,7 +33,7 @@ const AUDIO_BASE_URL = "https://verses.quran.com";
  */
 function normalizeVerseRecitations(
   audioFiles: RawVerseRecitation[],
-): VerseRecitation[] {
+): NormalizedVerseRecitation[] {
   return audioFiles.map((file) => {
     // If url is already absolute, use it; otherwise prepend the base URL
     const absoluteUrl =
@@ -108,7 +109,10 @@ export class QuranAudio {
     chapterId: ChapterId,
     recitationId: string,
     options?: GetVerseRecitationOptions,
-  ): Promise<{ audioFiles: VerseRecitation[]; pagination: Pagination }> {
+  ): Promise<{
+    audioFiles: NormalizedVerseRecitation[];
+    pagination: Pagination;
+  }> {
     if (!isValidChapterId(chapterId)) throw new Error("Invalid chapter id");
 
     const data = await this.fetcher.fetch<{
@@ -137,7 +141,10 @@ export class QuranAudio {
     key: VerseKey,
     recitationId: string,
     options?: GetVerseRecitationOptions,
-  ): Promise<{ audioFiles: VerseRecitation[]; pagination: Pagination }> {
+  ): Promise<{
+    audioFiles: NormalizedVerseRecitation[];
+    pagination: Pagination;
+  }> {
     if (!isValidVerseKey(key)) throw new Error("Invalid verse key");
 
     const data = await this.fetcher.fetch<{

--- a/packages/api/src/types/api/AudioData.ts
+++ b/packages/api/src/types/api/AudioData.ts
@@ -11,7 +11,10 @@ export interface ChapterRecitation {
 
 export interface VerseRecitation {
   verseKey: VerseKey;
+  /** Relative URL path (e.g., "AbdulBaset/Murattal/mp3/002255.mp3") */
   url: string;
+  /** Absolute URL (e.g., "https://download.quranicaudio.com/qdc/AbdulBaset/Murattal/mp3/002255.mp3") */
+  audioUrl: string;
 
   id?: number;
   chapterId?: number;

--- a/packages/api/src/types/api/AudioData.ts
+++ b/packages/api/src/types/api/AudioData.ts
@@ -13,7 +13,7 @@ export interface VerseRecitation {
   verseKey: VerseKey;
   /** Relative URL path (e.g., "AbdulBaset/Murattal/mp3/002255.mp3") */
   url: string;
-  /** Absolute URL (e.g., "https://download.quranicaudio.com/qdc/AbdulBaset/Murattal/mp3/002255.mp3") */
+  /** Absolute URL (e.g., "https://verses.quran.com/AbdulBaset/Murattal/mp3/002255.mp3") */
   audioUrl: string;
 
   id?: number;

--- a/packages/api/src/types/api/AudioData.ts
+++ b/packages/api/src/types/api/AudioData.ts
@@ -13,11 +13,15 @@ export interface VerseRecitation {
   verseKey: VerseKey;
   /** Relative URL path (e.g., "AbdulBaset/Murattal/mp3/002255.mp3") */
   url: string;
-  /** Absolute URL (e.g., "https://verses.quran.com/AbdulBaset/Murattal/mp3/002255.mp3") */
-  audioUrl: string;
+  /** Absolute URL when returned by SDK helpers (e.g., "https://verses.quran.com/AbdulBaset/Murattal/mp3/002255.mp3") */
+  audioUrl?: string;
 
   id?: number;
   chapterId?: number;
   segments?: Segment[];
   format?: string;
 }
+
+export type NormalizedVerseRecitation = VerseRecitation & {
+  audioUrl: string;
+};

--- a/packages/api/test/audio.test.ts
+++ b/packages/api/test/audio.test.ts
@@ -98,7 +98,9 @@ describe("Audio API", () => {
       );
       expect(response.audioFiles[0]).toBeDefined();
       // The relative URL from the mock
-      expect(response.audioFiles[0].url).toBe("AbdulBaset/Murattal/mp3/001001.mp3");
+      expect(response.audioFiles[0].url).toBe(
+        "AbdulBaset/Murattal/mp3/001001.mp3",
+      );
       // The normalized absolute URL
       expect(response.audioFiles[0].audioUrl).toBe(
         "https://verses.quran.com/AbdulBaset/Murattal/mp3/001001.mp3",
@@ -133,11 +135,25 @@ describe("Audio API", () => {
       );
       expect(response.audioFiles[0]).toBeDefined();
       // The relative URL from the mock (002255.mp3 for verse 2:255)
-      expect(response.audioFiles[0].url).toBe("AbdulBaset/Murattal/mp3/002255.mp3");
+      expect(response.audioFiles[0].url).toBe(
+        "AbdulBaset/Murattal/mp3/002255.mp3",
+      );
       // The normalized absolute URL
       expect(response.audioFiles[0].audioUrl).toBe(
         "https://verses.quran.com/AbdulBaset/Murattal/mp3/002255.mp3",
       );
+    });
+
+    it("should preserve already absolute URLs as audioUrl", async () => {
+      const response = await testClient.audio.findVerseRecitationsByKey(
+        VALID_VERSE_KEY,
+        VALID_RECITATION_ID,
+      );
+      const absoluteUrl =
+        "https://verses.quran.com/AbdulBaset/Murattal/mp3/002255.mp3";
+      expect(response.audioFiles[1]).toBeDefined();
+      expect(response.audioFiles[1].url).toBe(absoluteUrl);
+      expect(response.audioFiles[1].audioUrl).toBe(absoluteUrl);
     });
 
     it("should throw error for invalid verse key", async () => {

--- a/packages/api/test/audio.test.ts
+++ b/packages/api/test/audio.test.ts
@@ -88,6 +88,21 @@ describe("Audio API", () => {
         VALID_RECITATION_ID,
       );
       expect(response).toBeDefined();
+      expect(response.audioFiles).toBeInstanceOf(Array);
+    });
+
+    it("should normalize relative URLs to absolute audioUrl", async () => {
+      const response = await testClient.audio.findVerseRecitationsByChapter(
+        VALID_CHAPTER_ID,
+        VALID_RECITATION_ID,
+      );
+      expect(response.audioFiles[0]).toBeDefined();
+      // The relative URL from the mock
+      expect(response.audioFiles[0].url).toBe("AbdulBaset/Murattal/mp3/001001.mp3");
+      // The normalized absolute URL
+      expect(response.audioFiles[0].audioUrl).toBe(
+        "https://verses.quran.com/AbdulBaset/Murattal/mp3/001001.mp3",
+      );
     });
 
     it("should throw error for invalid chapter ID", async () => {
@@ -108,6 +123,21 @@ describe("Audio API", () => {
         VALID_RECITATION_ID,
       );
       expect(response).toBeDefined();
+      expect(response.audioFiles).toBeInstanceOf(Array);
+    });
+
+    it("should normalize relative URLs to absolute audioUrl", async () => {
+      const response = await testClient.audio.findVerseRecitationsByKey(
+        VALID_VERSE_KEY,
+        VALID_RECITATION_ID,
+      );
+      expect(response.audioFiles[0]).toBeDefined();
+      // The relative URL from the mock (002255.mp3 for verse 2:255)
+      expect(response.audioFiles[0].url).toBe("AbdulBaset/Murattal/mp3/002255.mp3");
+      // The normalized absolute URL
+      expect(response.audioFiles[0].audioUrl).toBe(
+        "https://verses.quran.com/AbdulBaset/Murattal/mp3/002255.mp3",
+      );
     });
 
     it("should throw error for invalid verse key", async () => {

--- a/packages/api/test/audio.test.ts
+++ b/packages/api/test/audio.test.ts
@@ -134,13 +134,11 @@ describe("Audio API", () => {
         VALID_RECITATION_ID,
       );
       expect(response.audioFiles[0]).toBeDefined();
-      // The relative URL from the mock (002255.mp3 for verse 2:255)
       expect(response.audioFiles[0].url).toBe(
-        "AbdulBaset/Murattal/mp3/002255.mp3",
+        "AbdulBaset/Murattal/mp3/001001.mp3",
       );
-      // The normalized absolute URL
       expect(response.audioFiles[0].audioUrl).toBe(
-        "https://verses.quran.com/AbdulBaset/Murattal/mp3/002255.mp3",
+        "https://verses.quran.com/AbdulBaset/Murattal/mp3/001001.mp3",
       );
     });
 
@@ -150,7 +148,7 @@ describe("Audio API", () => {
         VALID_RECITATION_ID,
       );
       const absoluteUrl =
-        "https://verses.quran.com/AbdulBaset/Murattal/mp3/002255.mp3";
+        "https://verses.quran.com/AbdulBaset/Murattal/mp3/001001.mp3";
       expect(response.audioFiles[1]).toBeDefined();
       expect(response.audioFiles[1].url).toBe(absoluteUrl);
       expect(response.audioFiles[1].audioUrl).toBe(absoluteUrl);


### PR DESCRIPTION
## Description

Currently, the `findVerseRecitationsByChapter()` and `findVerseRecitationsByKey()` methods in the Quran Audio API return relative URL paths (e.g., `AbdulBaset/Murattal/mp3/002255.mp3`) for verse recitations, while `findAllChapterRecitations()` returns absolute URLs (e.g., `https://download.quranicaudio.com/qdc/...`).

**The Problem:**
- The API returns a relative path like `AbdulBaset/Murattal/mp3/002255.mp3`, It doesn't even tell us what the base URL is! Furthermore, the chapter recitation base URL (`https://download.quranicaudio.com/qdc/`) does not work with verse recitations. Users have no way to know the correct base URL without external documentation or trial and error

**The Solution:**
This PR normalizes verse recitation URLs to absolute paths by prepending the correct base URL (`https://verses.quran.com/`), ensuring consistent behavior across all audio methods.

## Changes Made

1. **Updated `VerseRecitation` type** (`src/types/api/AudioData.ts`)
   - Added `audioUrl: string` field alongside existing `url` field
   - Added JSDoc comments explaining both fields

2. **Added URL normalization** (`src/sdk/audio.ts`)
   - Introduced `AUDIO_BASE_URL = "https://verses.quran.com"`
   - Added `normalizeVerseRecitations()` helper function
   - Applied normalization to `findVerseRecitationsByChapter()` and `findVerseRecitationsByKey()`

3. **Updated mocks** (`mocks/handlers.ts`)
   - Added `url` field with relative paths to verse recitation mock responses

4. **Added tests** (`test/audio.test.ts`)
   - New test cases verifying both `url` (relative) and `audioUrl` (absolute) fields

## API Changes

**Before:**
```typescript
const { audioFiles } = await client.audio.findVerseRecitationsByKey("2:255", "2");
console.log(audioFiles[0].url); 
// "AbdulBaset/Murattal/mp3/002255.mp3" 
// Relative path - where do we prepend? What base URL?
```

**After:**
```typescript
const { audioFiles } = await client.audio.findVerseRecitationsByKey("2:255", "2");
console.log(audioFiles[0].url);      
// "AbdulBaset/Murattal/mp3/002255.mp3" (relative - preserved for backward compatibility)
console.log(audioFiles[0].audioUrl); 
// "https://verses.quran.com/AbdulBaset/Murattal/mp3/002255.mp3" 
// Absolute URL - works immediately!
```

## Backward Compatibility

**Fully backward compatible** - The original `url` field is preserved with the relative path, and the new `audioUrl` field provides the normalized absolute URL. Eventually, I believe only one of the fields should be kept. Also, need to figure out what to do when baseURL is manually overridden in the client config. 

I'm not sure how this function ever got past review when the relative url doesn't even work, was I missing something?

