### PR TITLE
[codex] Fix user API query parameter casing

### DIFF
--- a/.changeset/green-files-share.md
+++ b/.changeset/green-files-share.md
@@ -1,0 +1,5 @@
+---
+"@quranjs/api": minor
+---
+
+Update casing of params

--- a/packages/api/src/lib/url.ts
+++ b/packages/api/src/lib/url.ts
@@ -30,6 +30,10 @@ export const replacePathParams = (
 export const normalizePathTemplate = (path: string): string =>
   path.replace(/(^|\/):([A-Za-z0-9_]+)/g, "$1{$2}");
 
+interface ParamsToStringOptions {
+  preserveCase?: boolean;
+}
+
 const fieldsKey = ["wordFields", "translationFields", "fields"] as const;
 const fieldsKeySet = new Set<string>([
   ...fieldsKey,
@@ -40,7 +44,10 @@ const preservedKeys = new Set([
   "versesResultsNumber",
 ]);
 
-export const paramsToString = (params?: ApiParams): string => {
+export const paramsToString = (
+  params?: ApiParams,
+  options: ParamsToStringOptions = {},
+): string => {
   if (!params) return "";
 
   const paramsString = new URLSearchParams();
@@ -48,7 +55,10 @@ export const paramsToString = (params?: ApiParams): string => {
   for (const [rawKey, rawValue] of Object.entries(params)) {
     if (rawValue === undefined) continue;
 
-    const key = preservedKeys.has(rawKey) ? rawKey : decamelize(rawKey);
+    const key =
+      options.preserveCase || preservedKeys.has(rawKey)
+        ? rawKey
+        : decamelize(rawKey);
 
     // fields is a special case, it's an object with boolean values
     if (fieldsKeySet.has(rawKey) || fieldsKeySet.has(key)) {

--- a/packages/api/src/runtime/create-client.ts
+++ b/packages/api/src/runtime/create-client.ts
@@ -39,6 +39,9 @@ type QuranReflectFacade = {
   users: GeneratedGroup;
 };
 
+const LEGACY_BOOKMARK_GET_MESSAGE =
+  "auth.bookmarks.get(bookmarkId) is not supported because /v1/bookmarks/bookmark expects bookmark detail query parameters. Pass a query object such as { mushafId, key, type, verseNumber } or { mushafId, isReading: true }.";
+
 const createUserServiceRequest =
   (fetcher: QuranFetcher, service: AuthService) =>
   (method: HTTPMethod, path: string, request?: OperationRequest) => {
@@ -102,10 +105,15 @@ const createAuthFacade = (fetcher: QuranFetcher) => {
       ...generatedGroups.bookmarks,
       create: (body: Record<string, unknown>) =>
         request("POST", "/v1/bookmarks", { body }),
-      get: (query?: ApiParams) =>
-        request("GET", "/v1/bookmarks/bookmark", {
+      get: async (query?: ApiParams | string) => {
+        if (typeof query === "string") {
+          throw new Error(LEGACY_BOOKMARK_GET_MESSAGE);
+        }
+
+        return request("GET", "/v1/bookmarks/bookmark", {
           query,
-        }),
+        });
+      },
       list: (query?: ApiParams) => request("GET", "/v1/bookmarks", { query }),
       listCollections: (query?: ApiParams) =>
         request("GET", "/v1/bookmarks/collections", { query }),

--- a/packages/api/src/runtime/create-client.ts
+++ b/packages/api/src/runtime/create-client.ts
@@ -14,7 +14,7 @@ import type {
   VerseKey,
 } from "@/types";
 import { operationCatalog } from "@/generated/contracts";
-import { AuthService } from "@/generated/public-contracts";
+import type { AuthService } from "@/generated/public-contracts";
 import { toUserSession } from "@/lib/http-utils";
 import { createGeneratedGroups, createRawClient } from "@/lib/runtime-utils";
 import { replacePathParams } from "@/lib/url";
@@ -102,9 +102,9 @@ const createAuthFacade = (fetcher: QuranFetcher) => {
       ...generatedGroups.bookmarks,
       create: (body: Record<string, unknown>) =>
         request("POST", "/v1/bookmarks", { body }),
-      get: (bookmarkId: string) =>
+      get: (query?: ApiParams) =>
         request("GET", "/v1/bookmarks/bookmark", {
-          query: { bookmarkId },
+          query,
         }),
       list: (query?: ApiParams) => request("GET", "/v1/bookmarks", { query }),
       listCollections: (query?: ApiParams) =>

--- a/packages/api/src/runtime/create-public-client.ts
+++ b/packages/api/src/runtime/create-public-client.ts
@@ -25,6 +25,8 @@ type QuranReflectFacade = {
 
 const SERVER_ONLY_MESSAGE =
   "This API requires @quranjs/api/server or a backend. Content and search are server-side for confidential clients.";
+const LEGACY_BOOKMARK_GET_MESSAGE =
+  "auth.bookmarks.get(bookmarkId) is not supported because /v1/bookmarks/bookmark expects bookmark detail query parameters. Pass a query object such as { mushafId, key, type, verseNumber } or { mushafId, isReading: true }.";
 
 const createUserServiceRequest =
   (fetcher: PublicQuranFetcher, service: AuthService) =>
@@ -92,10 +94,15 @@ const createAuthFacade = (fetcher: PublicQuranFetcher) => {
       ...generatedGroups.bookmarks,
       create: (body: Record<string, unknown>) =>
         request("POST", "/v1/bookmarks", { body }),
-      get: (query?: ApiParams) =>
-        request("GET", "/v1/bookmarks/bookmark", {
+      get: async (query?: ApiParams | string) => {
+        if (typeof query === "string") {
+          throw new Error(LEGACY_BOOKMARK_GET_MESSAGE);
+        }
+
+        return request("GET", "/v1/bookmarks/bookmark", {
           query,
-        }),
+        });
+      },
       list: (query?: ApiParams) => request("GET", "/v1/bookmarks", { query }),
       listCollections: (query?: ApiParams) =>
         request("GET", "/v1/bookmarks/collections", { query }),

--- a/packages/api/src/runtime/create-public-client.ts
+++ b/packages/api/src/runtime/create-public-client.ts
@@ -5,10 +5,8 @@ import type {
   PublicClientConfig,
   TokenResponse,
 } from "@/types";
-import {
-  AuthService,
-  publicOperationCatalog,
-} from "@/generated/public-contracts";
+import type { AuthService } from "@/generated/public-contracts";
+import { publicOperationCatalog } from "@/generated/public-contracts";
 import { toUserSession } from "@/lib/http-utils";
 import { createGeneratedGroups, createRawClient } from "@/lib/runtime-utils";
 import { replacePathParams } from "@/lib/url";
@@ -94,9 +92,9 @@ const createAuthFacade = (fetcher: PublicQuranFetcher) => {
       ...generatedGroups.bookmarks,
       create: (body: Record<string, unknown>) =>
         request("POST", "/v1/bookmarks", { body }),
-      get: (bookmarkId: string) =>
+      get: (query?: ApiParams) =>
         request("GET", "/v1/bookmarks/bookmark", {
-          query: { bookmarkId },
+          query,
         }),
       list: (query?: ApiParams) => request("GET", "/v1/bookmarks", { query }),
       listCollections: (query?: ApiParams) =>

--- a/packages/api/src/sdk/fetcher.ts
+++ b/packages/api/src/sdk/fetcher.ts
@@ -164,8 +164,12 @@ export class QuranFetcher {
       usesGateway,
       crossServiceGatewayPath,
     );
+    const preserveQueryParamCase =
+      service === "auth" || service === "quranReflect";
 
-    return `${baseUrl}${servicePath}${paramsToString(query)}`;
+    return `${baseUrl}${servicePath}${paramsToString(query, {
+      preserveCase: preserveQueryParamCase,
+    })}`;
   }
 
   public async requestOperation<T = unknown>(

--- a/packages/api/src/sdk/public-fetcher.ts
+++ b/packages/api/src/sdk/public-fetcher.ts
@@ -88,7 +88,12 @@ export class PublicQuranFetcher {
   ): string {
     const { baseUrl, usesGateway } = this.resolveServiceBaseUrl(service);
     const servicePath = this.normalizeServicePath(service, path, usesGateway);
-    return `${baseUrl}${servicePath}${paramsToString(query)}`;
+    const preserveQueryParamCase =
+      service === "auth" || service === "quranReflect";
+
+    return `${baseUrl}${servicePath}${paramsToString(query, {
+      preserveCase: preserveQueryParamCase,
+    })}`;
   }
 
   public async requestOperation<T = unknown>(

--- a/packages/api/test/raw-operation.test.ts
+++ b/packages/api/test/raw-operation.test.ts
@@ -191,6 +191,23 @@ describe("raw operation requests", () => {
     );
   });
 
+  it("rejects legacy server bookmark id lookup calls", async () => {
+    const client = createServerClient({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      services: {
+        authBaseUrl: "http://localhost:3001",
+      },
+      userSession: {
+        accessToken: "user-token",
+      },
+    });
+
+    await expect(client.auth.bookmarks.get("bookmark-1")).rejects.toThrow(
+      "auth.bookmarks.get(bookmarkId) is not supported",
+    );
+  });
+
   it("routes content-catalog gateway paths without the content prefix", async () => {
     let feedUrl: string | null = null;
     let commentsUrl: string | null = null;
@@ -400,6 +417,23 @@ describe("raw operation requests", () => {
 
     expect(bookmarkUrl).toBe(
       "http://localhost:3001/v1/bookmarks/bookmark?isReading=true&mushafId=1",
+    );
+  });
+
+  it("rejects legacy public bookmark id lookup calls", async () => {
+    const client = createPublicClient({
+      clientId: "client-id",
+      clientType: "confidential-proxy",
+      services: {
+        authBaseUrl: "http://localhost:3001",
+      },
+      userSession: {
+        accessToken: "user-token",
+      },
+    });
+
+    await expect(client.auth.bookmarks.get("bookmark-1")).rejects.toThrow(
+      "auth.bookmarks.get(bookmarkId) is not supported",
     );
   });
 

--- a/packages/api/test/raw-operation.test.ts
+++ b/packages/api/test/raw-operation.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, it } from "vitest";
 import type { OperationDefinition } from "../src/generated/contracts";
 import type { OperationDefinition as PublicOperationDefinition } from "../src/generated/public-contracts";
 import { server } from "../mocks/server";
+import { createPublicClient } from "../src/public";
 import { QuranFetcher } from "../src/sdk/fetcher";
 import { PublicQuranFetcher } from "../src/sdk/public-fetcher";
+import { createServerClient } from "../src/server";
 
 describe("raw operation requests", () => {
   it("replaces server raw operation path params before fetching", async () => {
@@ -109,6 +111,84 @@ describe("raw operation requests", () => {
     expect(
       fetcher.buildServiceUrl("content", "/recitations/1/by_ayah/1:1"),
     ).toBe("http://localhost:3020/api/v4/recitations/1/by_ayah/1:1");
+  });
+
+  it("preserves server user-service query parameter casing", () => {
+    const fetcher = new QuranFetcher("server", {
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      services: {
+        authBaseUrl: "http://localhost:3001",
+      },
+    });
+
+    expect(
+      fetcher.buildServiceUrl("auth", "/v1/bookmarks", {
+        first: 5,
+        mushafId: 1,
+        sortBy: "recentlyAdded",
+      }),
+    ).toBe(
+      "http://localhost:3001/v1/bookmarks?first=5&mushafId=1&sortBy=recentlyAdded",
+    );
+  });
+
+  it("preserves server Quran Reflect query parameter casing", () => {
+    const fetcher = new QuranFetcher("server", {
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      services: {
+        quranReflectBaseUrl: "http://localhost:3002",
+      },
+    });
+
+    expect(
+      fetcher.buildServiceUrl("quranReflect", "/v1/posts/feed", {
+        postTypeIds: [1, 2],
+        postingAsUserId: 123,
+        sortBy: "recent",
+      }),
+    ).toBe(
+      "http://localhost:3002/v1/posts/feed?postTypeIds=1%2C2&postingAsUserId=123&sortBy=recent",
+    );
+  });
+
+  it("passes bookmark detail queries through the server auth wrapper", async () => {
+    let bookmarkUrl: string | null = null;
+
+    server.use(
+      http.get("http://localhost:3001/v1/bookmarks/bookmark", ({ request }) => {
+        bookmarkUrl = request.url;
+        expect(request.headers.get("x-auth-token")).toBe("user-token");
+
+        return HttpResponse.json({
+          id: "bookmark-1",
+        });
+      }),
+    );
+
+    const client = createServerClient({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      services: {
+        authBaseUrl: "http://localhost:3001",
+      },
+      userSession: {
+        accessToken: "user-token",
+      },
+    });
+
+    await client.auth.bookmarks.get({
+      isReading: false,
+      key: 2,
+      mushafId: 1,
+      type: "ayah",
+      verseNumber: 255,
+    });
+
+    expect(bookmarkUrl).toBe(
+      "http://localhost:3001/v1/bookmarks/bookmark?isReading=false&key=2&mushafId=1&type=ayah&verseNumber=255",
+    );
   });
 
   it("routes content-catalog gateway paths without the content prefix", async () => {
@@ -245,6 +325,81 @@ describe("raw operation requests", () => {
 
     expect(fetcher.buildServiceUrl("auth", "/v1/notes/:noteId")).toBe(
       "http://localhost:3001/v1/notes/{noteId}",
+    );
+  });
+
+  it("preserves public user-service query parameter casing", () => {
+    const fetcher = new PublicQuranFetcher({
+      clientId: "client-id",
+      clientType: "confidential-proxy",
+      services: {
+        authBaseUrl: "http://localhost:3001",
+      },
+    });
+
+    expect(
+      fetcher.buildServiceUrl("auth", "/v1/streaks", {
+        first: 5,
+        orderBy: "startDate",
+        sortOrder: "desc",
+      }),
+    ).toBe(
+      "http://localhost:3001/v1/streaks?first=5&orderBy=startDate&sortOrder=desc",
+    );
+  });
+
+  it("preserves public Quran Reflect query parameter casing", () => {
+    const fetcher = new PublicQuranFetcher({
+      clientId: "client-id",
+      clientType: "confidential-proxy",
+      services: {
+        quranReflectBaseUrl: "http://localhost:3002",
+      },
+    });
+
+    expect(
+      fetcher.buildServiceUrl("quranReflect", "/v1/users/search", {
+        postingAs: "user",
+        postingAsUserId: 123,
+        roomId: 456,
+      }),
+    ).toBe(
+      "http://localhost:3002/v1/users/search?postingAs=user&postingAsUserId=123&roomId=456",
+    );
+  });
+
+  it("passes bookmark detail queries through the public auth wrapper", async () => {
+    let bookmarkUrl: string | null = null;
+
+    server.use(
+      http.get("http://localhost:3001/v1/bookmarks/bookmark", ({ request }) => {
+        bookmarkUrl = request.url;
+        expect(request.headers.get("x-auth-token")).toBe("user-token");
+
+        return HttpResponse.json({
+          id: "bookmark-1",
+        });
+      }),
+    );
+
+    const client = createPublicClient({
+      clientId: "client-id",
+      clientType: "confidential-proxy",
+      services: {
+        authBaseUrl: "http://localhost:3001",
+      },
+      userSession: {
+        accessToken: "user-token",
+      },
+    });
+
+    await client.auth.bookmarks.get({
+      isReading: true,
+      mushafId: 1,
+    });
+
+    expect(bookmarkUrl).toBe(
+      "http://localhost:3001/v1/bookmarks/bookmark?isReading=true&mushafId=1",
     );
   });
 


### PR DESCRIPTION
## Summary

This follow-up fixes the user API issues we found while smoke testing the published npm package, not a local file-linked SDK build. During the PoC smoke test against `@quranjs/api@3.0.0`, pre-live `Auth bookmarks.list` failed with `422 Unprocessable Entity`. Inspecting the request showed the SDK was sending `mushaf_id`, while the User API contract expects `mushafId`.

The same serializer path is shared by server/public clients and by both User API services, so this fixes the behavior at the service boundary instead of patching one endpoint at a time.

## What Changed

- Preserve query parameter casing for `auth` and `quranReflect` service requests in both server and public fetchers.
- Keep existing decamelized query behavior for content/search APIs.
- Fix `auth.bookmarks.get` in both server and public facades to pass the backend contract query object to `/v1/bookmarks/bookmark` instead of sending a non-contract `bookmarkId` query.
- Keep the legacy `auth.bookmarks.get(bookmarkId)` call shape type-compatible, but reject it with a clear migration error instead of making a known-bad backend request.
- Add regression coverage for:
  - server auth query casing (`mushafId`, `sortBy`)
  - server Quran Reflect query casing (`postTypeIds`, `postingAsUserId`, `sortBy`)
  - public auth query casing (`orderBy`, `sortOrder`)
  - public Quran Reflect query casing (`postingAs`, `postingAsUserId`, `roomId`)
  - server/public `auth.bookmarks.get` wrapper query forwarding
  - server/public legacy bookmark-id lookup rejection

## Why

The backend contract for User APIs and Quran Reflect APIs uses camelCase query parameters. The SDK was globally decamelizing query keys, which is correct for content/search endpoints but wrong for `auth` and `quranReflect` endpoints. That made some published-package smoke tests pass only when they happened not to use camelCase query params, while endpoints such as bookmarks failed once `mushafId` was included.

## Validation

- `pnpm --filter @quranjs/api exec vitest run test/raw-operation.test.ts` passed, 15 tests.
- `pnpm --filter @quranjs/api build` passed under Node 24.14.0.
- `pnpm --filter @quranjs/api lint` passed with one pre-existing warning in `src/types/quran-client.ts`.
- `pnpm --filter @quranjs/api exec vitest run --exclude test/operation-catalog-generator.test.js` passed, 111 tests.

Full `pnpm --filter @quranjs/api test` still fails on `test/operation-catalog-generator.test.js` with a parse-time `SyntaxError: Invalid or unexpected token` at its external generator import. That suite is unrelated to this patch; the same syntax checks pass for both the test file and `scripts/generate-operation-catalogs.mjs` directly.

## Out Of Scope

- `/v1/sync` catalog/live-docs drift.
- Endpoint-specific SDK docs/examples for User APIs and Quran Reflect.
- Strong generated TypeScript parameter types for every operation.