### PR TITLE
[codex] Add SDK support for Content v4 Answers endpoints

### DIFF
--- a/.changeset/v4-answers-sdk.md
+++ b/.changeset/v4-answers-sdk.md
@@ -1,0 +1,5 @@
+---
+"@quranjs/api": minor
+---
+
+Add first-class SDK methods and types for the public Content v4 answers endpoints.

--- a/packages/api/mocks/handlers.ts
+++ b/packages/api/mocks/handlers.ts
@@ -877,6 +877,86 @@ export const handlers = [
   ),
 
   http.get(
+    "https://apis.quran.foundation/content/api/v4/answers/by_ayah/:ayah_key",
+    ({ params }) => {
+      return HttpResponse.json({
+        questions: [
+          {
+            id: "question-1",
+            body: "What is the context of this ayah?",
+            type: "CLARIFICATION",
+            ranges: [params.ayah_key],
+            surah: 2,
+            theme: ["Faith"],
+            summary: "A short summary",
+            references: ["Tafsir al-Tabari"],
+            language: "en",
+            status: "Published",
+            answers: [
+              {
+                id: "answer-1",
+                body: "This ayah is known as Ayat al-Kursi.",
+                answeredBy: "Scholar",
+                status: "Published",
+                language: "en",
+              },
+            ],
+          },
+        ],
+        totalCount: 1,
+      });
+    },
+  ),
+
+  http.get(
+    "https://apis.quran.foundation/content/api/v4/answers/count_within_range",
+    () => {
+      return HttpResponse.json({
+        "2:255": {
+          total: 2,
+          types: {
+            CLARIFICATION: 1,
+            TAFSIR: 1,
+          },
+        },
+        "2:256": {
+          total: 1,
+          types: {
+            TAFSIR: 1,
+          },
+        },
+      });
+    },
+  ),
+
+  http.get(
+    "https://apis.quran.foundation/content/api/v4/answers/:question_id",
+    ({ params }) => {
+      return HttpResponse.json({
+        id: params.question_id,
+        body: "What is the context of this ayah?",
+        type: "CLARIFICATION",
+        ranges: ["2:255"],
+        surah: 2,
+        theme: ["Faith"],
+        summary: "A short summary",
+        references: ["Tafsir al-Tabari"],
+        language: "en",
+        status: "Published",
+        answers: [
+          {
+            id: "answer-1",
+            body: "This ayah is known as Ayat al-Kursi.",
+            answeredBy: "Scholar",
+            status: "Published",
+            language: "en",
+          },
+        ],
+      });
+    },
+  ),
+
+  http.get(
     "https://apis.quran.foundation/content/api/v4/resources/verse_media",
     () => {
       return HttpResponse.json({

--- a/packages/api/src/lib/url.ts
+++ b/packages/api/src/lib/url.ts
@@ -41,6 +41,7 @@ const fieldsKeySet = new Set<string>([
 ]);
 const preservedKeys = new Set([
   "navigationalResultsNumber",
+  "pageSize",
   "versesResultsNumber",
 ]);
 

--- a/packages/api/src/runtime/create-client.ts
+++ b/packages/api/src/runtime/create-client.ts
@@ -18,6 +18,7 @@ import { operationCatalog } from "@/generated/contracts";
 import { toUserSession } from "@/lib/http-utils";
 import { createGeneratedGroups, createRawClient } from "@/lib/runtime-utils";
 import { replacePathParams } from "@/lib/url";
+import { QuranAnswers } from "@/sdk/answers";
 import { QuranAudio } from "@/sdk/audio";
 import { QuranChapters } from "@/sdk/chapters";
 import { QuranFetcher } from "@/sdk/fetcher";
@@ -345,6 +346,7 @@ const createOAuth2Facade = (
 };
 
 const createContentFacade = (
+  answers: QuranAnswers,
   chapters: QuranChapters,
   verses: QuranVerses,
   juzs: QuranJuzs,
@@ -354,6 +356,14 @@ const createContentFacade = (
   raw: Record<string, RawOperation>,
 ) => {
   return {
+    answers: {
+      byAyah: (key: VerseKey, query?: ApiParams) =>
+        answers.findByAyah(key, query),
+      countWithinRange: (from: VerseKey, to: VerseKey, query?: ApiParams) =>
+        answers.countWithinRange(from, to, query),
+      get: (questionId: string | number) =>
+        answers.findByQuestionId(questionId),
+    },
     audio: {
       chapterRecitation: {
         get: (reciterId: string, chapterId: ChapterId, query?: ApiParams) =>
@@ -447,6 +457,7 @@ export const createRuntimeClient = (
 ) => {
   const fetcher = new QuranFetcher(mode, config);
   fetcher.getFetch();
+  const answers = new QuranAnswers(fetcher);
   const chapters = new QuranChapters(fetcher);
   const verses = new QuranVerses(fetcher);
   const juzs = new QuranJuzs(fetcher);
@@ -474,6 +485,7 @@ export const createRuntimeClient = (
   };
 
   const contentV4 = createContentFacade(
+    answers,
     chapters,
     verses,
     juzs,
@@ -503,6 +515,7 @@ export const createRuntimeClient = (
   });
 
   return {
+    answers,
     audio,
     auth: {
       ...authV1,

--- a/packages/api/src/runtime/create-public-client.ts
+++ b/packages/api/src/runtime/create-public-client.ts
@@ -348,6 +348,7 @@ export const createPublicRuntimeClient = (config: PublicClientConfig) => {
   };
 
   return {
+    answers: serverOnlyGuard,
     audio: serverOnlyGuard,
     auth: {
       ...authV1,

--- a/packages/api/src/sdk/answers.ts
+++ b/packages/api/src/sdk/answers.ts
@@ -1,0 +1,108 @@
+import type {
+  AnswerCountWithinRangeResponse,
+  AnswerQuestion,
+  AnswersByAyahResponse,
+  BaseApiParams,
+  QuranFetchClient,
+  VerseKey,
+} from "@/types";
+import { isValidVerseKey } from "@/utils";
+
+type GetAnswersByAyahOptions = BaseApiParams & {
+  page?: number;
+  pageSize?: number;
+};
+
+type CountAnswersWithinRangeOptions = BaseApiParams;
+
+const normalizeAnswerCountWithinRangeResponse = (
+  response: AnswerCountWithinRangeResponse,
+): AnswerCountWithinRangeResponse => {
+  return Object.fromEntries(
+    Object.entries(response).map(([verseKey, count]) => {
+      if (!count.types) return [verseKey, count];
+
+      return [
+        verseKey,
+        {
+          ...count,
+          types: Object.fromEntries(
+            Object.entries(count.types).map(([type, value]) => [
+              type.toUpperCase(),
+              value,
+            ]),
+          ),
+        },
+      ];
+    }),
+  );
+};
+
+/**
+ * Quran answers API methods.
+ */
+export class QuranAnswers {
+  constructor(private fetcher: QuranFetchClient) {}
+
+  /**
+   * Get published answer questions linked to a specific ayah.
+   * @param {VerseKey} key verse key in format "chapter:verse" (e.g., "2:255")
+   * @param {GetAnswersByAyahOptions} options
+   * @example
+   * client.answers.findByAyah("2:255", { page: 1, pageSize: 2 })
+   */
+  async findByAyah(
+    key: VerseKey,
+    options?: GetAnswersByAyahOptions,
+  ): Promise<AnswersByAyahResponse> {
+    if (!isValidVerseKey(key)) throw new Error("Invalid verse key");
+
+    return this.fetcher.fetch<AnswersByAyahResponse>(
+      `/content/api/v4/answers/by_ayah/${key}`,
+      options,
+    );
+  }
+
+  /**
+   * Get a published answer question by id.
+   * @param {string | number} questionId question id
+   * @example
+   * client.answers.findByQuestionId("988")
+   */
+  async findByQuestionId(
+    questionId: string | number,
+  ): Promise<AnswerQuestion> {
+    return this.fetcher.fetch<AnswerQuestion>(
+      `/content/api/v4/answers/${questionId}`,
+    );
+  }
+
+  /**
+   * Get a verse-key to answer-count map within an inclusive ayah range.
+   * @param {VerseKey} from start verse key in format "chapter:verse"
+   * @param {VerseKey} to end verse key in format "chapter:verse"
+   * @param {CountAnswersWithinRangeOptions} options
+   * @example
+   * client.answers.countWithinRange("2:255", "2:256")
+   */
+  async countWithinRange(
+    from: VerseKey,
+    to: VerseKey,
+    options?: CountAnswersWithinRangeOptions,
+  ): Promise<AnswerCountWithinRangeResponse> {
+    if (!isValidVerseKey(from) || !isValidVerseKey(to)) {
+      throw new Error("Invalid verse key");
+    }
+
+    const response = await this.fetcher.fetch<AnswerCountWithinRangeResponse>(
+      "/content/api/v4/answers/count_within_range",
+      {
+        ...options,
+        from,
+        to,
+      },
+    );
+
+    return normalizeAnswerCountWithinRangeResponse(response);
+  }
+}

--- a/packages/api/src/sdk/client.ts
+++ b/packages/api/src/sdk/client.ts
@@ -12,6 +12,7 @@ import { paramsToString, removeBeginningSlash } from "@/lib/url";
 import { Language } from "@/types";
 import humps from "humps";
 
+import { QuranAnswers } from "./answers";
 import { QuranAudio } from "./audio";
 import { QuranChapters } from "./chapters";
 import { QuranHadithReferences } from "./hadith-references";
@@ -130,6 +131,7 @@ export class QuranClient {
   private fetcher: LegacyQuranFetcher;
 
   public readonly chapters: QuranChapters;
+  public readonly answers: QuranAnswers;
   public readonly verses: QuranVerses;
   public readonly juzs: QuranJuzs;
   public readonly audio: QuranAudio;
@@ -151,6 +153,7 @@ export class QuranClient {
     this.fetcher = new LegacyQuranFetcher(this.config);
     this.fetcher.getFetch();
 
+    this.answers = new QuranAnswers(this.fetcher);
     this.chapters = new QuranChapters(this.fetcher);
     this.verses = new QuranVerses(this.fetcher);
     this.juzs = new QuranJuzs(this.fetcher);

--- a/packages/api/src/types/api/Answer.ts
+++ b/packages/api/src/types/api/Answer.ts
@@ -1,0 +1,35 @@
+import type { VerseKey } from "../common/verse-key";
+
+export interface Answer {
+  id: string | number;
+  body: string;
+  answeredBy?: string;
+  status: string;
+  language?: string;
+}
+
+export interface AnswerQuestion {
+  id: string | number;
+  body: string;
+  type: string;
+  ranges: VerseKey[];
+  surah: number;
+  theme?: string[];
+  summary?: string;
+  references?: string[];
+  language?: string;
+  status: string;
+  answers: Answer[];
+}
+
+export interface AnswersByAyahResponse {
+  questions: AnswerQuestion[];
+  totalCount?: number;
+}
+
+export interface AnswerCount {
+  types?: Record<string, number>;
+  total: number;
+}
+
+export type AnswerCountWithinRangeResponse = Record<string, AnswerCount>;

--- a/packages/api/src/types/api/index.ts
+++ b/packages/api/src/types/api/index.ts
@@ -1,4 +1,5 @@
 export * from './ApiResponses';
+export * from './Answer';
 export * from './AudioData';
 export * from './AudioResponse';
 export * from './Chapter';

--- a/packages/api/test/answers.test.ts
+++ b/packages/api/test/answers.test.ts
@@ -1,0 +1,101 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { server } from "../mocks/server";
+import { testClient } from "./test-client";
+
+describe("Answers API", () => {
+  describe("findByAyah()", () => {
+    it("should return answer questions for a valid ayah key", async () => {
+      const response = await testClient.answers.findByAyah("2:255");
+
+      expect(response.totalCount).toBe(1);
+      expect(response.questions[0]).toMatchObject({
+        id: "question-1",
+        ranges: ["2:255"],
+        surah: 2,
+      });
+      expect(response.questions[0]?.answers[0]?.answeredBy).toBe("Scholar");
+    });
+
+    it("should preserve pageSize casing for the public answers contract", async () => {
+      let requestUrl = "http://missing.test";
+
+      server.use(
+        http.get(
+          "https://apis.quran.foundation/content/api/v4/answers/by_ayah/:ayah_key",
+          ({ request }) => {
+            requestUrl = request.url;
+
+            return HttpResponse.json({
+              questions: [],
+              totalCount: 0,
+            });
+          },
+        ),
+      );
+
+      await testClient.answers.findByAyah("2:255", {
+        language: "en",
+        page: 1,
+        pageSize: 2,
+      });
+
+      const params = new URL(requestUrl).searchParams;
+      expect(params.get("page")).toBe("1");
+      expect(params.get("pageSize")).toBe("2");
+      expect(params.get("page_size")).toBeNull();
+    });
+
+    it("should throw for invalid ayah keys", async () => {
+      await expect(
+        // @ts-expect-error - invalid verse key
+        testClient.answers.findByAyah("0:1"),
+      ).rejects.toThrowError("Invalid verse key");
+    });
+  });
+
+  describe("findByQuestionId()", () => {
+    it("should return a published question by id", async () => {
+      const response = await testClient.answers.findByQuestionId("question-1");
+
+      expect(response.id).toBe("question-1");
+      expect(response.answers[0]?.body).toContain("Ayat al-Kursi");
+    });
+  });
+
+  describe("countWithinRange()", () => {
+    it("should return answer counts for a verse range", async () => {
+      await expect(
+        testClient.answers.countWithinRange("2:255", "2:256"),
+      ).resolves.toEqual({
+        "2:255": {
+          total: 2,
+          types: {
+            CLARIFICATION: 1,
+            TAFSIR: 1,
+          },
+        },
+        "2:256": {
+          total: 1,
+          types: {
+            TAFSIR: 1,
+          },
+        },
+      });
+    });
+
+    it("should throw for invalid verse ranges", async () => {
+      await expect(
+        // @ts-expect-error - invalid verse key
+        testClient.answers.countWithinRange("2:255", "0:1"),
+      ).rejects.toThrowError("Invalid verse key");
+    });
+
+    it("should expose the same methods through content.v4", async () => {
+      const response = await testClient.content.v4.answers.byAyah("2:255");
+
+      expect(response.questions[0]?.answers[0]?.id).toBe("answer-1");
+    });
+  });
+});

--- a/packages/api/test/answers.test.ts
+++ b/packages/api/test/answers.test.ts
@@ -93,9 +93,16 @@ describe("Answers API", () => {
     });
 
     it("should expose the same methods through content.v4", async () => {
-      const response = await testClient.content.v4.answers.byAyah("2:255");
+      const byAyah = await testClient.content.v4.answers.byAyah("2:255");
+      const answer = await testClient.content.v4.answers.get("question-1");
+      const count = await testClient.content.v4.answers.countWithinRange(
+        "2:255",
+        "2:256",
+      );
 
-      expect(response.questions[0]?.answers[0]?.id).toBe("answer-1");
+      expect(byAyah.questions[0]?.answers[0]?.id).toBe("answer-1");
+      expect(answer.answers[0]?.body).toContain("Ayat al-Kursi");
+      expect(count["2:255"]?.types?.TAFSIR).toBe(1);
     });
   });
 });

--- a/packages/api/test/legacy-client.test.ts
+++ b/packages/api/test/legacy-client.test.ts
@@ -106,4 +106,64 @@ describe("QuranClient legacy compatibility", () => {
       perPage: 5,
     });
   });
+
+  it("exposes answers through the legacy root client", async () => {
+    let answersUrl = "http://missing.test";
+
+    server.use(
+      http.post("http://localhost:5444/oauth2/token", () =>
+        HttpResponse.json({
+          access_token: "legacy-token",
+          expires_in: 3600,
+          scope: "content search",
+          token_type: "Bearer",
+        }),
+      ),
+      http.get(
+        "http://localhost:3020/content/api/v4/answers/by_ayah/:ayah_key",
+        ({ request }) => {
+          answersUrl = request.url;
+          expect(request.headers.get("x-auth-token")).toBe("legacy-token");
+          expect(request.headers.get("x-client-id")).toBe("client-id");
+
+          return HttpResponse.json({
+            questions: [
+              {
+                id: "question-1",
+                answers: [],
+                body: "What is the context of this ayah?",
+                ranges: ["2:255"],
+                status: "Published",
+                surah: 2,
+                type: "TAFSIR",
+              },
+            ],
+            totalCount: 1,
+          });
+        },
+      ),
+    );
+
+    const client = new QuranClient({
+      authBaseUrl: "http://localhost:5444",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      contentBaseUrl: "http://localhost:3020",
+    });
+
+    await expect(
+      client.answers.findByAyah("2:255", {
+        language: "en",
+        pageSize: 2,
+      }),
+    ).resolves.toMatchObject({
+      questions: [{ id: "question-1" }],
+      totalCount: 1,
+    });
+
+    const params = new URL(answersUrl).searchParams;
+    expect(params.get("language")).toBe("en");
+    expect(params.get("pageSize")).toBe("2");
+    expect(params.get("page_size")).toBeNull();
+  });
 });

--- a/packages/api/test/public-client.test.ts
+++ b/packages/api/test/public-client.test.ts
@@ -48,8 +48,12 @@ describe("createPublicClient", () => {
     const content = client.content as {
       v4: { chapters: { list: () => Promise<unknown> } };
     };
+    const answers = client.answers as {
+      findByAyah: (key: string) => Promise<unknown>;
+    };
 
     await expect(content.v4.chapters.list()).rejects.toThrowError(/server/i);
+    await expect(answers.findByAyah("2:255")).rejects.toThrowError(/server/i);
 
     const response =
       (await client.auth.v1.collections.list()) as CollectionListResponse;


### PR DESCRIPTION
﻿## Summary

- Add first-class SDK types and methods for the public Content v4 Answers endpoints introduced by quran/quran.com-api#800.
- Expose the endpoints through both `client.answers` and `client.content.v4.answers` in the server runtime, with a server-only guard in the public runtime.
- Preserve the `pageSize` query parameter casing for `answers.byAyah`, because this endpoint's API contract uses camelCase there.
- Normalize answer count type buckets after response camelization so dynamic keys remain usable as `TAFSIR`, `CLARIFICATION`, etc.

## Why

While smoke testing the published `@quranjs/api` package through the `qf-user-poc`, we realized the recently merged quran/quran.com-api#800 endpoints were live and documented but did not have first-class SDK wrappers yet. The SDK could only reach them through generated raw operations, which meant consumers did not get the typed and ergonomic surface we expect for new Content v4 public APIs.

This follows the same process as the previous SDK follow-up: compare the merged API contract, add the missing SDK facade, test it in unit coverage, then install the local SDK build into the PoC and run live/prelive smoke checks before opening the PR.

## API Surface

```ts
await client.content.v4.answers.byAyah("1:1", {
  language: "en",
  page: 1,
  pageSize: 2,
});

await client.content.v4.answers.get("64");

await client.content.v4.answers.countWithinRange("1:1", "1:1", {
  language: "en",
});
```

The same calls are also available from the root content client as `client.answers.findByAyah`, `client.answers.findByQuestionId`, and `client.answers.countWithinRange`.

## Validation

- `pnpm --filter @quranjs/api lint` passes with the existing type-import warning in `packages/api/src/types/quran-client.ts` and Node module-type warning for `eslint.config.js`.
- `pnpm --filter @quranjs/api build`
- `pnpm --filter @quranjs/api exec vitest run --exclude test/operation-catalog-generator.test.js`
- Installed the local SDK build into `C:\Code\qf-user-poc` as `file:../api-js/packages/api` and verified the PoC displays `@quranjs/api@3.2.0 (local file: file:../api-js/packages/api)`.
- PoC live checks:
  - Pre-live `/sdk/content-answers/prelive`: 4 passed, 0 warnings, 0 failed.
  - Production `/sdk/content-answers/production`: 4 passed, 0 warnings, 0 failed.

## Docs

Docs PR #147 has been updated with the SDK Answers page and sidebar/runtime references: quran/qf-api-docs#147.
