### PR TITLE
[codex] Export public client session types

### DIFF
--- a/.changeset/public-type-exports.md
+++ b/.changeset/public-type-exports.md
@@ -1,0 +1,5 @@
+---
+"@quranjs/api": patch
+---
+
+Export public OAuth session and token storage types from the `/public` entrypoint.

--- a/packages/api/src/generated/specs/operation-catalog.json
+++ b/packages/api/src/generated/specs/operation-catalog.json
@@ -250,6 +250,21 @@
           "method": "get",
           "path": "/hadith_references/count_within_range"
         },
+        "listPages": {
+          "auth": "app",
+          "method": "get",
+          "path": "/pages"
+        },
+        "getPagesLookup": {
+          "auth": "app",
+          "method": "get",
+          "path": "/pages/lookup"
+        },
+        "getPagesPageNumber": {
+          "auth": "app",
+          "method": "get",
+          "path": "/pages/{page_number}"
+        },
         "versesByChapterNumber": {
           "auth": "app",
           "method": "get",
@@ -659,6 +674,16 @@
           "auth": "app",
           "method": "get",
           "path": "/answers/count_within_range"
+        },
+        "resourcesSync": {
+          "auth": "app",
+          "method": "get",
+          "path": "/resources/sync"
+        },
+        "resourcesSnapshot": {
+          "auth": "app",
+          "method": "get",
+          "path": "/resources/snapshots/{resource_group}/{id}"
         }
       },
       "service": "content",

--- a/packages/api/src/public.ts
+++ b/packages/api/src/public.ts
@@ -2,6 +2,8 @@ import type { PublicClientConfig } from "@/types";
 
 import { createPublicRuntimeClient } from "./runtime/create-public-client";
 
+export type { TokenStorage, UserSession } from "@/types";
+
 export const createPublicClient = (config: PublicClientConfig) => {
   if ((config as PublicClientConfig & { clientSecret?: string }).clientSecret) {
     throw new Error("client_secret is server-only. Use @quranjs/api/server.");

--- a/packages/api/test/public-types.test.ts
+++ b/packages/api/test/public-types.test.ts
@@ -1,0 +1,93 @@
+import path from "node:path";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const formatDiagnostics = (diagnostics: readonly ts.Diagnostic[]): string =>
+  diagnostics
+    .map((diagnostic) => {
+      const message = ts.flattenDiagnosticMessageText(
+        diagnostic.messageText,
+        "\n",
+      );
+      if (!diagnostic.file || diagnostic.start === undefined) {
+        return `TS${diagnostic.code}: ${message}`;
+      }
+
+      const position = diagnostic.file.getLineAndCharacterOfPosition(
+        diagnostic.start,
+      );
+      const location = [
+        path.basename(diagnostic.file.fileName),
+        position.line + 1,
+        position.character + 1,
+      ].join(":");
+      return `${location} TS${diagnostic.code}: ${message}`;
+    })
+    .join("\n");
+
+describe("@quranjs/api/public type surface", () => {
+  it("exports public session storage types", () => {
+    const sourceFile = path.join(
+      process.cwd(),
+      "test",
+      "__public-entrypoint-types.ts",
+    );
+    const source = `
+      import type { PublicClient, TokenStorage, UserSession } from "@quranjs/api/public";
+
+      const storage: TokenStorage = {
+        getSession: async (): Promise<UserSession | null> => ({
+          accessToken: "access-token",
+        }),
+        setSession: async (_session: UserSession | null) => undefined,
+        clearSession: async () => undefined,
+      };
+      const client: PublicClient | null = null;
+
+      void storage;
+      void client;
+    `;
+    const options: ts.CompilerOptions = {
+      baseUrl: process.cwd(),
+      esModuleInterop: true,
+      lib: ["lib.es2022.d.ts", "lib.dom.d.ts"],
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      noEmit: true,
+      paths: {
+        "@/*": ["src/*"],
+        "@quranjs/api/public": ["src/public.ts"],
+      },
+      skipLibCheck: true,
+      strict: true,
+      target: ts.ScriptTarget.ES2022,
+    };
+
+    const baseHost = ts.createCompilerHost(options);
+    const normalize = (filePath: string) =>
+      path.resolve(filePath).toLowerCase();
+    const normalizedSourceFile = normalize(sourceFile);
+    const compilerHost: ts.CompilerHost = {
+      ...baseHost,
+      fileExists: (filePath) =>
+        normalize(filePath) === normalizedSourceFile ||
+        baseHost.fileExists(filePath),
+      getSourceFile: (filePath, languageVersion, onError, shouldCreateNewFile) =>
+        normalize(filePath) === normalizedSourceFile
+          ? ts.createSourceFile(filePath, source, languageVersion, true)
+          : baseHost.getSourceFile(
+              filePath,
+              languageVersion,
+              onError,
+              shouldCreateNewFile,
+            ),
+      readFile: (filePath) =>
+        normalize(filePath) === normalizedSourceFile
+          ? source
+          : baseHost.readFile(filePath),
+    };
+
+    const program = ts.createProgram([sourceFile], options, compilerHost);
+    expect(formatDiagnostics(ts.getPreEmitDiagnostics(program))).toBe("");
+  });
+});


### PR DESCRIPTION
﻿## Summary

Fixes #59 by re-exporting the public OAuth session storage types from the `@quranjs/api/public` entrypoint.

The runtime public entrypoint already uses these types in its declaration surface, but only `createPublicClient` and `PublicClient` were exported. Consumers importing `TokenStorage` or `UserSession` from `@quranjs/api/public` hit TypeScript export errors even though the root package entrypoint exported them.

## Changes

- Re-export `TokenStorage` and `UserSession` from `packages/api/src/public.ts` as type-only exports.
- Add a TypeScript compiler smoke test that imports the storage/session types from the public package subpath.
- Add a patch changeset for `@quranjs/api`.
- Refresh the generated operation catalog so CI matches the current OpenAPI source.

## Validation

- `pnpm --filter @quranjs/api build` with Node `v22.16.0`
- `pnpm --filter @quranjs/api exec vitest run test/public-types.test.ts test/public-client.test.ts`
- `pnpm --filter @quranjs/api check:operation-catalogs`
- `C:\Code\qf-user-poc` POC check: in-memory TypeScript compile importing `PublicClient`, `TokenStorage`, and `UserSession` from `@quranjs/api/public` against the linked local SDK build
