### PR TITLE
Add word-by-word translation content sync support

### DIFF
--- a/.changeset/word-by-word-content-sync.md
+++ b/.changeset/word-by-word-content-sync.md
@@ -1,0 +1,5 @@
+---
+"@quranjs/api": patch
+---
+
+Add typed content sync support for word-by-word translation resources.

--- a/apps/docs/content/docs/resources.mdx
+++ b/apps/docs/content/docs/resources.mdx
@@ -31,6 +31,8 @@ for (const mutation of page.sync.mutations) {
 
 If `page.sync.hasMore` is true, fetch `page.sync.nextPageUrl` through your backend or call `sync` again with the cursor from that URL. Store `page.sync.nextSyncToken` from the final bootstrap page.
 
+Sync tokens are bound to the canonical resource filter. Use the same `resources` value for bootstrap and incremental requests.
+
 ### Poll Incremental Changes
 
 ```ts
@@ -51,6 +53,38 @@ for (const mutation of changes.sync.mutations) {
 ```
 
 Use `client.content.v4.resources.sync(...)` and `client.content.v4.resources.findSnapshot(...)` when working through the namespaced v4 client.
+
+### Sync Word-by-Word Translations
+
+Use the resource content ID with the `word_by_word_translations` group. Only approved, shareable, translation-only one-word resources are available; transliterations are excluded.
+
+```ts
+import type { WordByWordTranslationSnapshotRecord } from "@quranjs/api";
+
+await client.resources.sync({
+  bootstrap: true,
+  resources: "word_by_word_translations:85",
+});
+
+const snapshot =
+  await client.resources.findSnapshot<WordByWordTranslationSnapshotRecord>(
+    "word_by_word_translations",
+    85,
+  );
+
+for (const record of snapshot.records) {
+  console.log(record.wordId, record.text);
+}
+```
+
+Snapshot records are returned in canonical `wordId`, `priority`, and `id` order. The SDK camel-cases their response fields.
+
+### WordByWordTranslationSnapshotRecord Type
+
+<auto-type-table
+  path="../../../../packages/api/src/types/api/Resources.ts"
+  name="WordByWordTranslationSnapshotRecord"
+/>
 
 ### ContentSyncResponse Type
 

--- a/packages/api/src/sdk/resources.ts
+++ b/packages/api/src/sdk/resources.ts
@@ -213,7 +213,10 @@ export class QuranResources {
    * Bootstrap or incrementally sync public content resources.
    * @param {ContentSyncOptions} options
    * @example
-   * client.resources.sync({ bootstrap: true, resources: "translations:19" })
+   * client.resources.sync({
+   *   bootstrap: true,
+   *   resources: "translations:19;word_by_word_translations:85"
+   * })
    */
   async sync<TData extends Record<string, unknown> = Record<string, unknown>>(
     options?: ContentSyncOptions,
@@ -230,7 +233,7 @@ export class QuranResources {
    * @param {string | number} id
    * @param {ContentResourceSnapshotOptions} options
    * @example
-   * client.resources.findSnapshot("translations", 19)
+   * client.resources.findSnapshot("word_by_word_translations", 85)
    */
   async findSnapshot<
     TRecord extends Record<string, unknown> = Record<string, unknown>,

--- a/packages/api/src/types/api/Resources.ts
+++ b/packages/api/src/types/api/Resources.ts
@@ -85,7 +85,21 @@ export type ContentSyncResourceGroup =
   | "articles"
   | "recitations"
   | "tafsirs"
-  | "translations";
+  | "translations"
+  | "word_by_word_translations";
+
+export interface WordByWordTranslationSnapshotRecord
+  extends Record<string, unknown> {
+  id: number;
+  resourceContentId: number;
+  resourceId: number;
+  wordId: number;
+  languageId: number;
+  languageName: string | null;
+  text: string | null;
+  priority: number | null;
+  updatedAt: string;
+}
 
 export type ContentSyncMutationType =
   | "RESOURCE_CREATE"
@@ -97,7 +111,7 @@ export type ContentSyncMutationType =
   | "RESOURCE_INVALIDATE";
 
 export interface ContentSyncOptions extends ApiParams {
-  /** Resource filter, e.g. `articles:*;translations:1,6`. */
+  /** Resource filter, e.g. `articles:*;translations:1,6;word_by_word_translations:85`. */
   resources?: string;
   /** Set to true for the initial sync. */
   bootstrap?: boolean;

--- a/packages/api/test/public-types.test.ts
+++ b/packages/api/test/public-types.test.ts
@@ -26,7 +26,7 @@ const formatDiagnostics = (diagnostics: readonly ts.Diagnostic[]): string =>
     .join("\n");
 
 describe("@quranjs/api/public type surface", () => {
-  it("exports public session storage types", () => {
+  it("exports public session and content sync types", () => {
     const sourceFile = path.join(
       process.cwd(),
       "test",
@@ -34,6 +34,10 @@ describe("@quranjs/api/public type surface", () => {
     );
     const source = `
       import type { PublicClient, TokenStorage, UserSession } from "@quranjs/api/public";
+      import type {
+        ContentSyncResourceGroup,
+        WordByWordTranslationSnapshotRecord,
+      } from "@quranjs/api";
 
       const storage: TokenStorage = {
         getSession: async (): Promise<UserSession | null> => ({
@@ -43,9 +47,31 @@ describe("@quranjs/api/public type surface", () => {
         clearSession: async () => undefined,
       };
       const client: PublicClient | null = null;
+      const resourceGroup: ContentSyncResourceGroup = "word_by_word_translations";
+      const record: WordByWordTranslationSnapshotRecord = {
+        id: 1,
+        resourceContentId: 85,
+        resourceId: 85,
+        wordId: 1,
+        languageId: 38,
+        languageName: "english",
+        text: "In",
+        priority: 1,
+        updatedAt: "2026-08-19T02:43:00Z",
+      };
+      const genericRecord: Record<string, unknown> = record;
+      const nullableRecord: WordByWordTranslationSnapshotRecord = {
+        ...record,
+        languageName: null,
+        text: null,
+        priority: null,
+      };
 
       void storage;
       void client;
+      void resourceGroup;
+      void genericRecord;
+      void nullableRecord;
     `;
     const options: ts.CompilerOptions = {
       baseUrl: process.cwd(),
@@ -56,6 +82,7 @@ describe("@quranjs/api/public type surface", () => {
       noEmit: true,
       paths: {
         "@/*": ["src/*"],
+        "@quranjs/api": ["src/index.ts"],
         "@quranjs/api/public": ["src/public.ts"],
       },
       skipLibCheck: true,
@@ -72,7 +99,12 @@ describe("@quranjs/api/public type surface", () => {
       fileExists: (filePath) =>
         normalize(filePath) === normalizedSourceFile ||
         baseHost.fileExists(filePath),
-      getSourceFile: (filePath, languageVersion, onError, shouldCreateNewFile) =>
+      getSourceFile: (
+        filePath,
+        languageVersion,
+        onError,
+        shouldCreateNewFile,
+      ) =>
         normalize(filePath) === normalizedSourceFile
           ? ts.createSourceFile(filePath, source, languageVersion, true)
           : baseHost.getSourceFile(

--- a/packages/api/test/resources.test.ts
+++ b/packages/api/test/resources.test.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
+import type { WordByWordTranslationSnapshotRecord } from "../src/types";
 import { server } from "../mocks/server";
 import { testClient } from "./test-client";
 
@@ -206,6 +207,64 @@ describe("Resources API", () => {
   });
 
   describe("findSnapshot()", () => {
+    it("returns camel-cased word-by-word translation records", async () => {
+      let requestUrl: URL | null = null;
+
+      server.use(
+        http.get(
+          "https://apis.quran.foundation/content/api/v4/resources/snapshots/word_by_word_translations/:id",
+          ({ request, params }) => {
+            requestUrl = new URL(request.url);
+            return HttpResponse.json({
+              resource_group: "word_by_word_translations",
+              resource_id: Number(params.id),
+              resource_content_id: Number(params.id),
+              schema_version: 1,
+              sync_sequence: 98101,
+              records: [
+                {
+                  id: 1,
+                  resource_content_id: 85,
+                  resource_id: 85,
+                  word_id: 1,
+                  language_id: 38,
+                  language_name: "english",
+                  text: "In",
+                  priority: 1,
+                  updated_at: "2026-08-19T02:43:00Z",
+                },
+              ],
+            });
+          },
+        ),
+      );
+
+      const snapshot =
+        await testClient.resources.findSnapshot<WordByWordTranslationSnapshotRecord>(
+          "word_by_word_translations",
+          85,
+        );
+
+      const url = expectCapturedUrl(requestUrl);
+      expect(url.pathname).toBe(
+        "/content/api/v4/resources/snapshots/word_by_word_translations/85",
+      );
+      expect(snapshot.resourceGroup).toBe("word_by_word_translations");
+      expect(snapshot.records).toEqual([
+        {
+          id: 1,
+          resourceContentId: 85,
+          resourceId: 85,
+          wordId: 1,
+          languageId: 38,
+          languageName: "english",
+          text: "In",
+          priority: 1,
+          updatedAt: "2026-08-19T02:43:00Z",
+        },
+      ]);
+    });
+
     it("serializes snapshot path params", async () => {
       let requestUrl: URL | null = null;
 


### PR DESCRIPTION
## Summary

- add word_by_word_translations to the public content sync resource-group type
- export a typed WordByWordTranslationSnapshotRecord matching the upstream snapshot payload and nullable legacy fields
- cover public exports, snapshot routing, and response camel-casing
- document bootstrap and snapshot usage, including canonical filter-bound sync tokens
- add a patch changeset for @quranjs/api

The existing sync() and findSnapshot() helpers already cover the endpoint, so no new SDK method is introduced.

## Upstream

- quran/quran.com-api#896

## Validation

- vitest run --maxWorkers=1 --minWorkers=1 — 144 tests passed
- tsup — CJS, ESM, and declaration builds passed
- Next.js documentation production build passed
- ESLint, Prettier, changeset status, and git diff checks passed
- Open Code Review delegate — no actionable findings
- Autoreview — patch is correct, no actionable findings (0.94 confidence)