### PR TITLE
chore: refresh operation catalogs

### DIFF
--- a/packages/api/src/generated/specs/operation-catalog.json
+++ b/packages/api/src/generated/specs/operation-catalog.json
@@ -703,6 +703,11 @@
           "method": "post",
           "path": "/oauth2/introspect"
         },
+        "revokeOauth2Token": {
+          "auth": "none",
+          "method": "post",
+          "path": "/oauth2/revoke"
+        },
         "oAuth2Authorize": {
           "auth": "none",
           "method": "get",
@@ -911,6 +916,11 @@
           "method": "get",
           "path": "/v1/posts/{postId}/related"
         },
+        "postsControllerGetReReflections": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/posts/{postId}/re-reflections"
+        },
         "postsControllerGetLoggedinUserPosts": {
           "auth": "user",
           "method": "get",
@@ -938,8 +948,13 @@
         },
         "postsControllerViewTracking": {
           "auth": "user",
-          "method": "get",
+          "method": "post",
           "path": "/v1/posts/viewed/{id}"
+        },
+        "postsControllerReadTracking": {
+          "auth": "user",
+          "method": "post",
+          "path": "/v1/posts/read/{id}"
         },
         "postsControllerCreate": {
           "auth": "user",
@@ -986,6 +1001,11 @@
           "method": "get",
           "path": "/v1/posts/count-within-range"
         },
+        "postsControllerGetPublicPostCountByVerse": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/posts/count-by-verse/{verseId}"
+        },
         "postsControllerGetMyPostsByVerse": {
           "auth": "user",
           "method": "get",
@@ -1020,6 +1040,11 @@
           "auth": "user",
           "method": "get",
           "path": "/v1/comments/{id}/replies"
+        },
+        "trendingHashtagsControllerFind": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/trending-hashtags"
         }
       },
       "service": "quranReflect",

--- a/packages/api/src/generated/specs/public-operation-catalog.json
+++ b/packages/api/src/generated/specs/public-operation-catalog.json
@@ -220,6 +220,11 @@
           "method": "post",
           "path": "/oauth2/introspect"
         },
+        "revokeOauth2Token": {
+          "auth": "none",
+          "method": "post",
+          "path": "/oauth2/revoke"
+        },
         "oAuth2Authorize": {
           "auth": "none",
           "method": "get",
@@ -428,6 +433,11 @@
           "method": "get",
           "path": "/v1/posts/{postId}/related"
         },
+        "postsControllerGetReReflections": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/posts/{postId}/re-reflections"
+        },
         "postsControllerGetLoggedinUserPosts": {
           "auth": "user",
           "method": "get",
@@ -455,8 +465,13 @@
         },
         "postsControllerViewTracking": {
           "auth": "user",
-          "method": "get",
+          "method": "post",
           "path": "/v1/posts/viewed/{id}"
+        },
+        "postsControllerReadTracking": {
+          "auth": "user",
+          "method": "post",
+          "path": "/v1/posts/read/{id}"
         },
         "postsControllerCreate": {
           "auth": "user",
@@ -503,6 +518,11 @@
           "method": "get",
           "path": "/v1/posts/count-within-range"
         },
+        "postsControllerGetPublicPostCountByVerse": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/posts/count-by-verse/{verseId}"
+        },
         "postsControllerGetMyPostsByVerse": {
           "auth": "user",
           "method": "get",
@@ -537,6 +557,11 @@
           "auth": "user",
           "method": "get",
           "path": "/v1/comments/{id}/replies"
+        },
+        "trendingHashtagsControllerFind": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/trending-hashtags"
         }
       },
       "service": "quranReflect",


### PR DESCRIPTION
## Summary

- Refresh the generated internal and public operation catalogs from the canonical OpenAPI specs.
- Capture the current OAuth and QuranReflect operation metadata, including the viewed-tracking GET-to-POST correction.
- Restore the catalog freshness gate that currently blocks CI and the release workflow.

## Why this follow-up is needed

PR #65 merged the word-by-word content-sync SDK support and its patch changeset, but its catalog check was stale because the generator reads the live qf-api-docs main specs. The release workflow exits at that check before Changesets can create the npm release PR.

No additional changeset is included here: the feature changeset is already on main.

## Verification

- Operation catalog freshness check passes
- Generator tests: 3 passed
- Full API test suite: 144 passed
- API production build and declaration generation pass
- Open Code Review delegation: no findings
- Autoreview: clean, no accepted or actionable findings

## After merge

The Changesets workflow should create or update the release PR for the pending patch release. Merging that release PR will publish the feature to npm.