### PR TITLE
Add typed Mushaf content sync support

### DIFF
--- a/.changeset/blue-mushafs-sync.md
+++ b/.changeset/blue-mushafs-sync.md
@@ -1,0 +1,5 @@
+---
+"@quranjs/api": minor
+---
+
+Add typed Mushaf resources and snapshot records to Content Sync.

--- a/apps/docs/content/docs/resources.mdx
+++ b/apps/docs/content/docs/resources.mdx
@@ -14,7 +14,7 @@ Use content sync when your app needs to cache public resources locally and keep 
 ```ts
 const page = await client.resources.sync({
   bootstrap: true,
-  resources: "articles:*;tafsirs:151;translations:1,6",
+  resources: "articles:*;mushafs:1;tafsirs:151;translations:1,6",
   perPage: 100,
 });
 
@@ -37,7 +37,7 @@ Sync tokens are bound to the canonical resource filter. Use the same `resources`
 
 ```ts
 const changes = await client.resources.sync({
-  resources: "articles:*;tafsirs:151;translations:1,6",
+  resources: "articles:*;mushafs:1;tafsirs:151;translations:1,6",
   syncToken: savedSyncToken,
 });
 
@@ -53,6 +53,38 @@ for (const mutation of changes.sync.mutations) {
 ```
 
 Use `client.content.v4.resources.sync(...)` and `client.content.v4.resources.findSnapshot(...)` when working through the namespaced v4 client.
+
+### Sync Mushafs for Offline Use
+
+Use the Mushaf ID with the `mushafs` group. Snapshots contain Mushaf metadata,
+page mappings, publicly distributable font assets, and positioned word records.
+
+```ts
+import type { MushafSnapshotRecord } from "@quranjs/api";
+
+await client.resources.sync({
+  bootstrap: true,
+  resources: "mushafs:1",
+});
+
+const snapshot = await client.resources.findSnapshot<MushafSnapshotRecord>(
+  "mushafs",
+  1,
+);
+
+for (const record of snapshot.records) {
+  if (record.recordType === "font_asset") {
+    console.log(record.fontFamily, record.url, record.sha256);
+  }
+}
+```
+
+### MushafSnapshotRecord Type
+
+<auto-type-table
+  path="../../../../packages/api/src/types/api/Resources.ts"
+  name="MushafSnapshotRecord"
+/>
 
 ### Sync Word-by-Word Translations
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -80,6 +80,28 @@ For complete documentation, guides, and API reference, visit:
 - 🎧 Audio recitations
 - 🌍 Multiple verified translations and languages
 
+## Content Sync
+
+Bootstrap an approved public Mushaf, download its snapshot for offline use, and
+then poll the same resource filter for incremental changes:
+
+```ts
+import type { MushafSnapshotRecord } from "@quranjs/api";
+
+const changes = await client.resources.sync({
+  bootstrap: true,
+  resources: "mushafs:1",
+});
+const snapshot = await client.resources.findSnapshot<MushafSnapshotRecord>(
+  "mushafs",
+  1,
+);
+```
+
+Mushaf snapshots include layout metadata, pages, publicly distributable font
+assets, and words. Store the final `nextSyncToken` and use it with the same
+`resources` filter on subsequent sync calls.
+
 ## Links
 
 - [Quran Foundation](https://quran.foundation) — Our mission to make the Quran accessible to everyone

--- a/packages/api/src/generated/specs/operation-catalog.json
+++ b/packages/api/src/generated/specs/operation-catalog.json
@@ -1041,6 +1041,11 @@
           "method": "get",
           "path": "/v1/comments/{id}/replies"
         },
+        "exploreControllerFind": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/explore"
+        },
         "trendingHashtagsControllerFind": {
           "auth": "user",
           "method": "get",

--- a/packages/api/src/generated/specs/public-operation-catalog.json
+++ b/packages/api/src/generated/specs/public-operation-catalog.json
@@ -558,6 +558,11 @@
           "method": "get",
           "path": "/v1/comments/{id}/replies"
         },
+        "exploreControllerFind": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/explore"
+        },
         "trendingHashtagsControllerFind": {
           "auth": "user",
           "method": "get",

--- a/packages/api/src/sdk/resources.ts
+++ b/packages/api/src/sdk/resources.ts
@@ -215,7 +215,7 @@ export class QuranResources {
    * @example
    * client.resources.sync({
    *   bootstrap: true,
-   *   resources: "translations:19;word_by_word_translations:85"
+   *   resources: "mushafs:1;translations:19;word_by_word_translations:85"
    * })
    */
   async sync<TData extends Record<string, unknown> = Record<string, unknown>>(
@@ -233,7 +233,7 @@ export class QuranResources {
    * @param {string | number} id
    * @param {ContentResourceSnapshotOptions} options
    * @example
-   * client.resources.findSnapshot("word_by_word_translations", 85)
+   * client.resources.findSnapshot("mushafs", 1)
    */
   async findSnapshot<
     TRecord extends Record<string, unknown> = Record<string, unknown>,

--- a/packages/api/src/types/api/Resources.ts
+++ b/packages/api/src/types/api/Resources.ts
@@ -83,10 +83,83 @@ export interface ChapterReciterResource {
 
 export type ContentSyncResourceGroup =
   | "articles"
+  | "mushafs"
   | "recitations"
   | "tafsirs"
   | "translations"
   | "word_by_word_translations";
+
+export interface MushafMetadataSnapshotRecord extends Record<string, unknown> {
+  recordType: "mushaf";
+  id: number;
+  resourceContentId: number;
+  name: string;
+  description: string | null;
+  pagesCount: number;
+  linesPerPage: number;
+  defaultFontName: string;
+  mappingMode: string;
+  qirat: { id: number; name: string } | null;
+}
+
+export interface MushafPageSnapshotRecord extends Record<string, unknown> {
+  recordType: "mushaf_page";
+  id: number;
+  mushafId: number;
+  pageNumber: number;
+  firstVerseId: number | null;
+  lastVerseId: number | null;
+  firstWordId: number | null;
+  lastWordId: number | null;
+  versesCount: number | null;
+  verseMapping: Record<string, unknown> | null;
+  updatedAt: string;
+}
+
+export interface MushafFontAssetSnapshotRecord extends Record<string, unknown> {
+  recordType: "font_asset";
+  id: number;
+  assetKey: string;
+  mushafId: number;
+  pageNumber: number | null;
+  fontFamily: string;
+  format: string;
+  mimeType: string;
+  url: string;
+  sha256: string;
+  byteSize: number;
+  version: string;
+  provider: string;
+  licenseName: string;
+  licenseUrl: string | null;
+  attribution: string | null;
+  updatedAt: string;
+}
+
+export interface MushafWordSnapshotRecord extends Record<string, unknown> {
+  recordType: "mushaf_word";
+  id: number;
+  mushafId: number;
+  wordId: number;
+  verseId: number;
+  sourceVerseId: number | null;
+  text: string | null;
+  charTypeId: number | null;
+  charTypeName: string | null;
+  pageNumber: number | null;
+  lineNumber: number | null;
+  positionInVerse: number | null;
+  positionInLine: number | null;
+  positionInPage: number | null;
+  cssClass: string | null;
+  cssStyle: string | null;
+}
+
+export type MushafSnapshotRecord =
+  | MushafMetadataSnapshotRecord
+  | MushafPageSnapshotRecord
+  | MushafFontAssetSnapshotRecord
+  | MushafWordSnapshotRecord;
 
 export interface WordByWordTranslationSnapshotRecord
   extends Record<string, unknown> {
@@ -111,7 +184,7 @@ export type ContentSyncMutationType =
   | "RESOURCE_INVALIDATE";
 
 export interface ContentSyncOptions extends ApiParams {
-  /** Resource filter, e.g. `articles:*;translations:1,6;word_by_word_translations:85`. */
+  /** Resource filter, e.g. `articles:*;mushafs:1;translations:1,6;word_by_word_translations:85`. */
   resources?: string;
   /** Set to true for the initial sync. */
   bootstrap?: boolean;

--- a/packages/api/test/public-types.test.ts
+++ b/packages/api/test/public-types.test.ts
@@ -36,6 +36,11 @@ describe("@quranjs/api/public type surface", () => {
       import type { PublicClient, TokenStorage, UserSession } from "@quranjs/api/public";
       import type {
         ContentSyncResourceGroup,
+        MushafFontAssetSnapshotRecord,
+        MushafMetadataSnapshotRecord,
+        MushafPageSnapshotRecord,
+        MushafSnapshotRecord,
+        MushafWordSnapshotRecord,
         WordByWordTranslationSnapshotRecord,
       } from "@quranjs/api";
 
@@ -48,6 +53,7 @@ describe("@quranjs/api/public type surface", () => {
       };
       const client: PublicClient | null = null;
       const resourceGroup: ContentSyncResourceGroup = "word_by_word_translations";
+      const mushafResourceGroup: ContentSyncResourceGroup = "mushafs";
       const record: WordByWordTranslationSnapshotRecord = {
         id: 1,
         resourceContentId: 85,
@@ -66,12 +72,83 @@ describe("@quranjs/api/public type surface", () => {
         text: null,
         priority: null,
       };
+      const mushafMetadata: MushafMetadataSnapshotRecord = {
+        recordType: "mushaf",
+        id: 1,
+        resourceContentId: 382,
+        name: "QCF V2",
+        description: null,
+        pagesCount: 604,
+        linesPerPage: 15,
+        defaultFontName: "v2",
+        mappingMode: "reference",
+        qirat: { id: 1, name: "Hafs" },
+      };
+      const mushafPage: MushafPageSnapshotRecord = {
+        recordType: "mushaf_page",
+        id: 10,
+        mushafId: 1,
+        pageNumber: 1,
+        firstVerseId: 1,
+        lastVerseId: 7,
+        firstWordId: 1,
+        lastWordId: 29,
+        versesCount: 7,
+        verseMapping: { "1": "1:1" },
+        updatedAt: "2026-08-19T02:43:00Z",
+      };
+      const fontAsset: MushafFontAssetSnapshotRecord = {
+        recordType: "font_asset",
+        id: 20,
+        assetKey: "page-001",
+        mushafId: 1,
+        pageNumber: 1,
+        fontFamily: "QCF_P001",
+        format: "woff2",
+        mimeType: "font/woff2",
+        url: "https://verses.quran.foundation/fonts/qcf-v2/p1.woff2",
+        sha256:
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        byteSize: 1234,
+        version: "1",
+        provider: "Quran Foundation",
+        licenseName: "Quran Foundation Font License",
+        licenseUrl: null,
+        attribution: null,
+        updatedAt: "2026-08-19T02:43:00Z",
+      };
+      const mushafWord: MushafWordSnapshotRecord = {
+        recordType: "mushaf_word",
+        id: 30,
+        mushafId: 1,
+        wordId: 1,
+        verseId: 1,
+        sourceVerseId: 1,
+        text: "ﱁ",
+        charTypeId: 1,
+        charTypeName: "word",
+        pageNumber: 1,
+        lineNumber: 1,
+        positionInVerse: 1,
+        positionInLine: 1,
+        positionInPage: 1,
+        cssClass: null,
+        cssStyle: null,
+      };
+      const mushafRecords: MushafSnapshotRecord[] = [
+        mushafMetadata,
+        mushafPage,
+        fontAsset,
+        mushafWord,
+      ];
 
       void storage;
       void client;
       void resourceGroup;
+      void mushafResourceGroup;
       void genericRecord;
       void nullableRecord;
+      void mushafRecords;
     `;
     const options: ts.CompilerOptions = {
       baseUrl: process.cwd(),

--- a/packages/api/test/resources.test.ts
+++ b/packages/api/test/resources.test.ts
@@ -1,7 +1,10 @@
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
-import type { WordByWordTranslationSnapshotRecord } from "../src/types";
+import type {
+  MushafSnapshotRecord,
+  WordByWordTranslationSnapshotRecord,
+} from "../src/types";
 import { server } from "../mocks/server";
 import { testClient } from "./test-client";
 
@@ -207,6 +210,120 @@ describe("Resources API", () => {
   });
 
   describe("findSnapshot()", () => {
+    it("returns typed camel-cased Mushaf records", async () => {
+      let requestUrl: URL | null = null;
+
+      server.use(
+        http.get(
+          "https://apis.quran.foundation/content/api/v4/resources/snapshots/mushafs/:id",
+          ({ request, params }) => {
+            requestUrl = new URL(request.url);
+            return HttpResponse.json({
+              resource_group: "mushafs",
+              resource_id: Number(params.id),
+              resource_content_id: 382,
+              schema_version: 1,
+              sync_sequence: 98102,
+              records: [
+                {
+                  record_type: "mushaf",
+                  id: 1,
+                  resource_content_id: 382,
+                  name: "QCF V2",
+                  description: null,
+                  pages_count: 604,
+                  lines_per_page: 15,
+                  default_font_name: "v2",
+                  mapping_mode: "reference",
+                  qirat: { id: 1, name: "Hafs" },
+                },
+                {
+                  record_type: "mushaf_page",
+                  id: 10,
+                  mushaf_id: 1,
+                  page_number: 1,
+                  first_verse_id: 1,
+                  last_verse_id: 7,
+                  first_word_id: 1,
+                  last_word_id: 29,
+                  verses_count: 7,
+                  verse_mapping: { "1": "1:1" },
+                  updated_at: "2026-08-19T02:43:00Z",
+                },
+                {
+                  record_type: "font_asset",
+                  id: 20,
+                  asset_key: "page-001",
+                  mushaf_id: 1,
+                  page_number: 1,
+                  font_family: "QCF_P001",
+                  format: "woff2",
+                  mime_type: "font/woff2",
+                  url: "https://verses.quran.foundation/fonts/qcf-v2/p1.woff2",
+                  sha256:
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  byte_size: 1234,
+                  version: "1",
+                  provider: "Quran Foundation",
+                  license_name: "Quran Foundation Font License",
+                  license_url: null,
+                  attribution: null,
+                  updated_at: "2026-08-19T02:43:00Z",
+                },
+                {
+                  record_type: "mushaf_word",
+                  id: 30,
+                  mushaf_id: 1,
+                  word_id: 1,
+                  verse_id: 1,
+                  source_verse_id: 1,
+                  text: "ﱁ",
+                  char_type_id: 1,
+                  char_type_name: "word",
+                  page_number: 1,
+                  line_number: 1,
+                  position_in_verse: 1,
+                  position_in_line: 1,
+                  position_in_page: 1,
+                  css_class: null,
+                  css_style: null,
+                },
+              ],
+            });
+          },
+        ),
+      );
+
+      const snapshot =
+        await testClient.resources.findSnapshot<MushafSnapshotRecord>(
+          "mushafs",
+          1,
+        );
+
+      const url = expectCapturedUrl(requestUrl);
+      expect(url.pathname).toBe(
+        "/content/api/v4/resources/snapshots/mushafs/1",
+      );
+      expect(snapshot.resourceGroup).toBe("mushafs");
+      expect(snapshot.records[0]).toMatchObject({
+        recordType: "mushaf",
+        resourceContentId: 382,
+        defaultFontName: "v2",
+        mappingMode: "reference",
+      });
+      expect(snapshot.records[2]).toMatchObject({
+        recordType: "font_asset",
+        assetKey: "page-001",
+        mimeType: "font/woff2",
+        byteSize: 1234,
+      });
+      expect(snapshot.records[3]).toMatchObject({
+        recordType: "mushaf_word",
+        sourceVerseId: 1,
+        positionInPage: 1,
+      });
+    });
+
     it("returns camel-cased word-by-word translation records", async () => {
       let requestUrl: URL | null = null;
 


### PR DESCRIPTION
## Summary
- add mushafs to the Content Sync resource group
- export typed metadata, page, font asset, and word snapshot records
- document offline Mushaf bootstrap and snapshot usage
- add a minor changeset

## Verification
- Vitest: 145 tests passed
- ESLint passed
- tsup production and declaration build passed