### PR TITLE
fix(release): gate publishing on full validation

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -4,8 +4,8 @@ description: "Common setup steps for Actions"
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
-    - uses: actions/setup-node@v4
+    - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
         cache: "pnpm"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,13 @@
 name: CI
 
 on:
+  workflow_call:
   pull_request:
     branches: ["*"]
-  push:
-    branches: ["main"]
   merge_group:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,7 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/setup
       - run: pnpm build --filter="./packages/*"
 
@@ -30,7 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/setup
       - run: pnpm --filter @quranjs/api check:operation-catalogs
 
@@ -39,7 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/setup
       - run: pnpm lint --quiet
 
@@ -48,7 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/setup
       - run: pnpm typecheck
 
@@ -57,6 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/setup
       - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,20 +9,29 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 env:
   HUSKY: 0
 
-permissions:
-  id-token: write # Required for OIDC
-  contents: write
-  issues: write
-  pull-requests: write
-  packages: write
+permissions: {}
 
 jobs:
+  validation:
+    name: Full validation
+    uses: ./.github/workflows/main.yml
+    permissions:
+      contents: read
+
   release:
     name: Release
     runs-on: ubuntu-latest
+    needs: validation
+    environment:
+      name: Production – api-js
+    permissions:
+      id-token: write # Required for npm trusted publishing.
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./.github/setup
@@ -45,8 +54,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Use OIDC for npm authentication instead of NPM_TOKEN
           NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
-
-
       # - name: Send a Slack notification if a publish happens
       #   if: steps.changesets.outputs.published == 'true'
       #   # You can do something when a publish happens.

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -12,17 +12,25 @@ env:
   FORCE_COLOR: 3
   HUSKY: 0
 
+permissions:
+  contents: read
+
 jobs:
   size:
     name: 📦 Size
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       CI_JOB_NUMBER: 1
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/setup
-      - uses: andresz1/size-limit-action@v1.8.0
+      - uses: andresz1/size-limit-action@94bc357df29c36c8f8d50ea497c3e225c3c95d1d # v1.8.0
         with:
           directory: packages/api/
           skip_step: install

--- a/packages/api/src/generated/specs/operation-catalog.json
+++ b/packages/api/src/generated/specs/operation-catalog.json
@@ -1041,6 +1041,11 @@
           "method": "get",
           "path": "/v1/comments/{id}/replies"
         },
+        "exploreControllerFind": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/explore"
+        },
         "trendingHashtagsControllerFind": {
           "auth": "user",
           "method": "get",

--- a/packages/api/src/generated/specs/public-operation-catalog.json
+++ b/packages/api/src/generated/specs/public-operation-catalog.json
@@ -558,6 +558,11 @@
           "method": "get",
           "path": "/v1/comments/{id}/replies"
         },
+        "exploreControllerFind": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/explore"
+        },
         "trendingHashtagsControllerFind": {
           "auth": "user",
           "method": "get",


### PR DESCRIPTION
## Summary

- make the existing CI workflow reusable
- run the complete build, operation-catalog, lint, typecheck, and test matrix before the npm release job
- keep npm trusted publishing in `.github/workflows/release.yml`, then grant OIDC/write permissions only to the release job
- scope publishing to the existing `Production – api-js` GitHub environment
- SHA-pin external actions and move setup actions to Node 24 runtimes
- refresh the two generated operation catalogs; the live schema added `exploreControllerFind` after the last green run

`main.yml` no longer runs separately on `main` pushes because `release.yml` calls it directly. This avoids running the full matrix twice for the same commit.

## Before merge

- [ ] Confirm npm trusted-publisher settings allow workflow `release.yml` with environment `Production – api-js`.
- [ ] Restrict the GitHub environment to `main` and add the desired release reviewers. The PR author only has read access and could not configure those admin-owned policies.

## Validation

- Actionlint: pass
- Zizmor high-severity/high-confidence: no findings
- lint: pass
- typecheck: pass (the current Turbo graph has no typecheck task)
- tests: 18 files / 144 tests pass
- generated operation catalogs: up to date
- package build: pass
