### PR TITLE
Add Analytics Events API client

### DIFF
--- a/.changeset/calm-events-arrive.md
+++ b/.changeset/calm-events-arrive.md
@@ -1,0 +1,5 @@
+---
+"@quranjs/api": minor
+---
+
+Add a server-only typed client for submitting Analytics Events batches with the `analytics.events.write` client-credentials scope.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -47,6 +47,39 @@ const results = await client.search.v1.query({
 });
 ```
 
+### Analytics Events
+
+Analytics submission uses the `analytics.events.write` scope and is available
+only from the server entrypoint. The SDK obtains and caches the required
+client-credentials token. Keep `CLIENT_SECRET` in server-side environment
+variables.
+
+```typescript
+const result = await client.analytics.v1.events.submit({
+  events: [
+    {
+      eventId: crypto.randomUUID(),
+      name: "quran.reader.verse_viewed",
+      version: 1,
+      occurredAt: new Date(),
+      userId: "QURAN_FOUNDATION_USER_ID",
+      sessionId: "session-123",
+      properties: { verseKey: "2:255", surface: "reader" },
+    },
+    {
+      eventId: crypto.randomUUID(),
+      name: "quran.app.started",
+      version: 1,
+      occurredAt: new Date(),
+      anonymousId: "anonymous-123",
+    },
+  ],
+});
+```
+
+A successful response accepts the complete batch. Retry a failed batch with
+the same event IDs so downstream processing can identify duplicates.
+
 For browser or mobile apps, use `@quranjs/api/public`. Public usage docs live in the API docs portal.
 
 Existing `QuranClient` imports from `@quranjs/api` remain supported for backwards compatibility:

--- a/packages/api/src/generated/contracts.ts
+++ b/packages/api/src/generated/contracts.ts
@@ -32,6 +32,7 @@ export interface ServiceOperationCatalog {
 }
 
 interface OperationCatalog {
+  analytics: { v1: ServiceOperationCatalog };
   auth: { v1: ServiceOperationCatalog };
   content: { v4: ServiceOperationCatalog };
   oauth2: { v1: ServiceOperationCatalog };

--- a/packages/api/src/generated/specs/operation-catalog.json
+++ b/packages/api/src/generated/specs/operation-catalog.json
@@ -1,4 +1,17 @@
 {
+  "analytics": {
+    "v1": {
+      "operations": {
+        "submitAnalyticsEvents": {
+          "auth": "app",
+          "method": "post",
+          "path": "/v1/events:batch"
+        }
+      },
+      "service": "analytics",
+      "version": "v1"
+    }
+  },
   "auth": {
     "v1": {
       "operations": {

--- a/packages/api/src/lib/service-config.ts
+++ b/packages/api/src/lib/service-config.ts
@@ -1,6 +1,7 @@
 export const API_BASE_URL = "https://apis.quran.foundation";
 
 export const DEFAULT_BASE_URLS = {
+  analytics: "https://apis.quran.foundation/analytics",
   auth: "https://apis.quran.foundation/auth",
   content: "https://apis.quran.foundation/content",
   oauth2: "https://oauth2.quran.foundation",
@@ -9,6 +10,7 @@ export const DEFAULT_BASE_URLS = {
 } as const;
 
 export const DIRECT_PATH_PREFIX = {
+  analytics: "/v1",
   auth: "/v1",
   content: "/api/v4",
   oauth2: "",
@@ -17,6 +19,7 @@ export const DIRECT_PATH_PREFIX = {
 } as const;
 
 export const GATEWAY_PATH_PREFIX = {
+  analytics: "/analytics/v1",
   auth: "/auth/v1",
   content: "/content/api/v4",
   oauth2: "",
@@ -25,6 +28,7 @@ export const GATEWAY_PATH_PREFIX = {
 } as const;
 
 export const LEGACY_PREFIXES = {
+  analytics: ["/analytics/v1", "/v1"] as const,
   auth: ["/auth/v1", "/v1"] as const,
   content: ["/content/api/v4", "/api/v4"] as const,
   oauth2: [] as const,

--- a/packages/api/src/runtime/analytics.ts
+++ b/packages/api/src/runtime/analytics.ts
@@ -1,0 +1,38 @@
+import type {
+  AnalyticsBatchAccepted,
+  AnalyticsBatchRequest,
+  AnalyticsEvent,
+  OperationRequest,
+} from "@/types";
+
+type RawOperation = (request?: OperationRequest) => Promise<unknown>;
+
+const optionalField = <T>(value: T | undefined, key: string) =>
+  value === undefined ? {} : { [key]: value };
+
+const toAnalyticsEventBody = (event: AnalyticsEvent) => ({
+  event_id: event.eventId,
+  name: event.name,
+  occurred_at:
+    event.occurredAt instanceof Date
+      ? event.occurredAt.toISOString()
+      : event.occurredAt,
+  version: event.version,
+  ...optionalField(event.actionId, "action_id"),
+  ...optionalField(event.anonymousId, "anonymous_id"),
+  ...optionalField(event.properties, "properties"),
+  ...optionalField(event.sessionId, "session_id"),
+  ...optionalField(event.userId, "user_id"),
+});
+
+export const createAnalyticsFacade = (raw: Record<string, RawOperation>) => ({
+  events: {
+    submit: (request: AnalyticsBatchRequest) =>
+      raw.submitAnalyticsEvents!({
+        body: {
+          events: request.events.map(toAnalyticsEventBody),
+        },
+      }) as Promise<AnalyticsBatchAccepted>,
+  },
+  raw,
+});

--- a/packages/api/src/runtime/create-client.ts
+++ b/packages/api/src/runtime/create-client.ts
@@ -1,4 +1,5 @@
 import type { AuthService } from "@/generated/public-contracts";
+import type { QuranReflectPostsFacade } from "@/runtime/quran-reflect-posts";
 import type {
   ApiParams,
   ChapterId,
@@ -20,8 +21,8 @@ import { operationCatalog } from "@/generated/contracts";
 import { toUserSession } from "@/lib/http-utils";
 import { createGeneratedGroups, createRawClient } from "@/lib/runtime-utils";
 import { replacePathParams } from "@/lib/url";
+import { createAnalyticsFacade } from "@/runtime/analytics";
 import { createQuranReflectPostsFacade } from "@/runtime/quran-reflect-posts";
-import type { QuranReflectPostsFacade } from "@/runtime/quran-reflect-posts";
 import { QuranAnswers } from "@/sdk/answers";
 import { QuranAudio } from "@/sdk/audio";
 import { QuranChapters } from "@/sdk/chapters";
@@ -480,6 +481,9 @@ export const createRuntimeClient = (
   const searchClient = new QuranSearch(fetcher);
 
   const raw = {
+    analytics: {
+      v1: createRawClient(fetcher, operationCatalog.analytics.v1),
+    },
     auth: {
       v1: createRawClient(fetcher, operationCatalog.auth.v1),
     },
@@ -507,6 +511,7 @@ export const createRuntimeClient = (
     resources,
     raw.content.v4,
   );
+  const analyticsV1 = createAnalyticsFacade(raw.analytics.v1);
   const authV1 = createAuthFacade(fetcher);
   const quranReflectV1 = createQuranReflectFacade(fetcher);
   const oauth2V1 = createOAuth2Facade(fetcher, mode, config);
@@ -528,6 +533,10 @@ export const createRuntimeClient = (
   });
 
   return {
+    analytics: {
+      ...analyticsV1,
+      v1: analyticsV1,
+    },
     answers,
     audio,
     auth: {

--- a/packages/api/src/sdk/fetcher.ts
+++ b/packages/api/src/sdk/fetcher.ts
@@ -34,6 +34,7 @@ const { camelizeKeys } = humps;
 type RuntimeClientConfig = PublicClientConfig | ServerClientConfig;
 
 const APP_SERVICE_SCOPES: Partial<Record<ApiService, string>> = {
+  analytics: "analytics.events.write",
   content: "content",
   search: "search",
 };
@@ -43,6 +44,7 @@ const QURAN_REFLECT_COMMENT_PATH_SUFFIXES = [
   "/all-comments",
 ] as const;
 const GATEWAY_SERVICES = [
+  "analytics",
   "auth",
   "content",
   "quranReflect",
@@ -659,15 +661,17 @@ export class QuranFetcher {
     }
 
     const directBaseUrl =
-      service === "content"
-        ? services?.contentBaseUrl
-        : service === "search"
-          ? services?.searchBaseUrl
-          : service === "auth"
-            ? services?.authBaseUrl
-            : service === "quranReflect"
-              ? services?.quranReflectBaseUrl
-              : (services?.oauth2BaseUrl ?? services?.tokenHost);
+      service === "analytics"
+        ? services?.analyticsBaseUrl
+        : service === "content"
+          ? services?.contentBaseUrl
+          : service === "search"
+            ? services?.searchBaseUrl
+            : service === "auth"
+              ? services?.authBaseUrl
+              : service === "quranReflect"
+                ? services?.quranReflectBaseUrl
+                : (services?.oauth2BaseUrl ?? services?.tokenHost);
 
     if (directBaseUrl) {
       return {

--- a/packages/api/src/types/analytics.ts
+++ b/packages/api/src/types/analytics.ts
@@ -1,0 +1,41 @@
+/** A JSON value accepted in an analytics event's properties object. */
+export type AnalyticsJsonValue =
+  | boolean
+  | null
+  | number
+  | string
+  | AnalyticsJsonValue[]
+  | { [key: string]: AnalyticsJsonValue };
+
+export interface AnalyticsEvent {
+  /** Stable caller-generated ID. Reuse it when retrying this event. */
+  eventId: string;
+  /** Namespaced event name, for example `quran.reader.verse_viewed`. */
+  name: string;
+  /** When the event happened. Date values are serialized as RFC 3339. */
+  occurredAt: Date | string;
+  /** Version of this event's property structure, starting at 1. */
+  version: number;
+  /** Optional ID linking the event to a specific action. */
+  actionId?: null | string;
+  /** Application-generated ID for a person who is not signed in. */
+  anonymousId?: null | string;
+  /** Event-specific JSON. Caller-defined property names are preserved. */
+  properties?: { [key: string]: AnalyticsJsonValue };
+  /** Application-generated ID grouping events from one usage session. */
+  sessionId?: null | string;
+  /** Quran Foundation OAuth user ID. Do not send an application-local ID. */
+  userId?: null | string;
+}
+
+export interface AnalyticsBatchRequest {
+  /** The API accepts between 1 and 100 events as one all-or-nothing batch. */
+  events: AnalyticsEvent[];
+}
+
+export interface AnalyticsBatchAccepted {
+  /** Number of accepted events; this equals the submitted count on HTTP 202. */
+  accepted: number;
+  /** Server-generated identifier shared by all events in this batch. */
+  batchId: string;
+}

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -124,5 +124,6 @@ export * from "./common/rub-number";
 
 export * from "./api";
 export * from "./BaseApiParams";
+export * from "./analytics";
 export * from "./quran-client";
 export * from "./quran-reflect";

--- a/packages/api/src/types/quran-client.ts
+++ b/packages/api/src/types/quran-client.ts
@@ -15,12 +15,18 @@ export interface QuranFetchClient {
   fetch<T = unknown>(url: string, params?: ApiParams): Promise<T>;
 }
 
-export type ApiService = "content" | "search" | AuthService | "oauth2";
+export type ApiService =
+  | "analytics"
+  | "content"
+  | "search"
+  | AuthService
+  | "oauth2";
 
 export interface ServiceEnvironmentConfig {
   gatewayUrl?: string;
   tokenHost?: string;
   oauth2BaseUrl?: string;
+  analyticsBaseUrl?: string;
   contentBaseUrl?: string;
   searchBaseUrl?: string;
   authBaseUrl?: string;

--- a/packages/api/test/analytics.test.ts
+++ b/packages/api/test/analytics.test.ts
@@ -1,0 +1,170 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { server } from "../mocks/server";
+import { createPublicClient } from "../src/public";
+import { createServerClient } from "../src/server";
+
+const EVENT_ID = "evt_01j60x3y6n7r8s9t0v1w2x3y4z";
+
+describe("Analytics Events API", () => {
+  it("submits typed events with the analytics client-credentials scope", async () => {
+    let tokenRequestBody = "";
+    let requestBody: unknown;
+    let requestHeaders: Headers | undefined;
+
+    server.use(
+      http.post("http://localhost:5444/oauth2/token", async ({ request }) => {
+        tokenRequestBody = await request.text();
+        expect(request.headers.get("authorization")).toBe(
+          `Basic ${Buffer.from("client-id:client-secret").toString("base64")}`,
+        );
+
+        return HttpResponse.json({
+          access_token: "analytics-token",
+          expires_in: 3600,
+          scope: "analytics.events.write",
+          token_type: "bearer",
+        });
+      }),
+      http.post(
+        "http://localhost:3030/v1/events:batch",
+        async ({ request }) => {
+          requestHeaders = request.headers;
+          requestBody = await request.json();
+
+          return HttpResponse.json(
+            {
+              accepted: 2,
+              batch_id: "d77a3c27-8365-4c57-a3ae-cf8ab8cb62c2",
+            },
+            { status: 202 },
+          );
+        },
+      ),
+    );
+
+    const client = createServerClient({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      services: {
+        analyticsBaseUrl: "http://localhost:3030",
+        tokenHost: "http://localhost:5444",
+      },
+    });
+
+    const response = await client.analytics.v1.events.submit({
+      events: [
+        {
+          eventId: EVENT_ID,
+          name: "quran.reader.verse_viewed",
+          occurredAt: new Date("2026-08-22T07:12:15Z"),
+          properties: {
+            already_snake_case: true,
+            callerDefinedKey: "preserved",
+          },
+          sessionId: "session-1",
+          userId: "qf-user-1",
+          version: 1,
+        },
+        {
+          anonymousId: "anonymous-1",
+          eventId: "evt_02j60x3y6n7r8s9t0v1w2x3y4z",
+          name: "quran.app.started",
+          occurredAt: "2026-08-22T07:12:16Z",
+          version: 1,
+        },
+      ],
+    });
+
+    expect(tokenRequestBody).toBe(
+      "grant_type=client_credentials&scope=analytics.events.write",
+    );
+    expect(requestHeaders?.get("x-client-id")).toBe("client-id");
+    expect(requestHeaders?.get("x-auth-token")).toBe("analytics-token");
+    expect(requestBody).toEqual({
+      events: [
+        {
+          event_id: EVENT_ID,
+          name: "quran.reader.verse_viewed",
+          occurred_at: "2026-08-22T07:12:15.000Z",
+          properties: {
+            already_snake_case: true,
+            callerDefinedKey: "preserved",
+          },
+          session_id: "session-1",
+          user_id: "qf-user-1",
+          version: 1,
+        },
+        {
+          anonymous_id: "anonymous-1",
+          event_id: "evt_02j60x3y6n7r8s9t0v1w2x3y4z",
+          name: "quran.app.started",
+          occurred_at: "2026-08-22T07:12:16Z",
+          version: 1,
+        },
+      ],
+    });
+    expect(response).toEqual({
+      accepted: 2,
+      batchId: "d77a3c27-8365-4c57-a3ae-cf8ab8cb62c2",
+    });
+  });
+
+  it("uses the Analytics Gateway path when gatewayUrl is configured", async () => {
+    let analyticsUrl = "";
+
+    server.use(
+      http.post("http://localhost:5444/oauth2/token", () =>
+        HttpResponse.json({
+          access_token: "analytics-token",
+          expires_in: 3600,
+        }),
+      ),
+      http.post(
+        "http://localhost:8787/analytics/v1/events:batch",
+        ({ request }) => {
+          analyticsUrl = request.url;
+          return HttpResponse.json(
+            { accepted: 1, batch_id: "batch-1" },
+            { status: 202 },
+          );
+        },
+      ),
+    );
+
+    const client = createServerClient({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      services: {
+        gatewayUrl: "http://localhost:8787",
+        tokenHost: "http://localhost:5444",
+      },
+    });
+
+    await client.analytics.v1.events.submit({
+      events: [
+        {
+          eventId: EVENT_ID,
+          name: "quran.app.started",
+          occurredAt: "2026-08-22T07:12:15Z",
+          version: 1,
+        },
+      ],
+    });
+
+    expect(analyticsUrl).toBe(
+      "http://localhost:8787/analytics/v1/events:batch",
+    );
+  });
+
+  it("does not expose Analytics through the public client", () => {
+    const client = createPublicClient({
+      clientId: "public-client-id",
+      clientType: "public",
+    });
+
+    expect("analytics" in client).toBe(false);
+    expect("analytics" in client.raw).toBe(false);
+  });
+});

--- a/packages/api/test/contracts.test.ts
+++ b/packages/api/test/contracts.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../src/generated/contracts";
 
 const representativeOperations = [
+  ["analytics", "v1", "submitAnalyticsEvents", "post", "/v1/events:batch"],
   ["content", "v4", "getChapter", "get", "/chapters/{id}"],
   [
     "content",
@@ -49,5 +50,11 @@ describe("operation contracts", () => {
     ).find((operation) => operation.path.includes("/v1/notes/{noteId}"));
 
     expect(noteOperation).toBeDefined();
+  });
+
+  it("preserves literal colon action suffixes", () => {
+    expect(
+      operationCatalog.analytics.v1.operations.submitAnalyticsEvents.path,
+    ).toBe("/v1/events:batch");
   });
 });

--- a/packages/api/test/operation-catalog-generator.test.js
+++ b/packages/api/test/operation-catalog-generator.test.js
@@ -49,6 +49,18 @@ describe("operation catalog generator", () => {
       path.join(os.tmpdir(), "quranjs-openapi-"),
     );
 
+    await writeJson(path.join(sourceDir, "analytics", "v1.json"), {
+      paths: {
+        "/v1/events:batch": {
+          post: {
+            operationId: "submit_analytics_events",
+            security: [{ "x-auth-token": [] }],
+            tags: ["Analytics Events"],
+          },
+        },
+      },
+      servers: [{ url: "https://apis.quran.foundation/analytics" }],
+    });
     await writeJson(path.join(sourceDir, "content", "v4.json"), {
       paths: {
         "/chapters/{id}": operation("GET-chapter"),
@@ -92,6 +104,19 @@ describe("operation catalog generator", () => {
     const catalogs = await generateCatalogs({ sourceDir });
 
     expect(catalogs.operationCatalog).toMatchObject({
+      analytics: {
+        v1: {
+          operations: {
+            submitAnalyticsEvents: {
+              auth: "app",
+              method: "post",
+              path: "/v1/events:batch",
+            },
+          },
+          service: "analytics",
+          version: "v1",
+        },
+      },
       auth: {
         v1: {
           operations: {
@@ -192,6 +217,9 @@ describe("operation catalog generator", () => {
       path.join(os.tmpdir(), "quranjs-openapi-"),
     );
 
+    await writeJson(path.join(sourceDir, "analytics", "v1.json"), {
+      paths: {},
+    });
     await writeJson(path.join(sourceDir, "content", "v4.json"), {
       paths: {},
     });

--- a/scripts/generate-operation-catalogs.mjs
+++ b/scripts/generate-operation-catalogs.mjs
@@ -18,6 +18,11 @@ const defaultOutputDir = path.join(
 );
 
 const inputSpecs = {
+  analytics: {
+    file: "analytics/v1.json",
+    service: "analytics",
+    version: "v1",
+  },
   content: {
     file: "content/v4.json",
     service: "content",
@@ -46,6 +51,7 @@ const createSection = (service, version) => ({
 });
 
 const createOperationCatalog = () => ({
+  analytics: { v1: createSection("analytics", "v1") },
   auth: { v1: createSection("auth", "v1") },
   content: { v4: createSection("content", "v4") },
   oauth2: { v1: createSection("oauth2", "v1") },
@@ -111,7 +117,7 @@ const ensureLeadingSlash = (value) =>
   value.startsWith("/") ? value : `/${value}`;
 
 const normalizePathTemplate = (route) => {
-  return route.replace(/:([A-Za-z_][\w]*)/g, "{$1}");
+  return route.replace(/(^|\/)\:([A-Za-z_][\w]*)/g, "$1{$2}");
 };
 
 const stripPrefix = (route, prefix, replacement = "") => {
@@ -231,6 +237,7 @@ const readSpecs = async ({
     : (relativePath) => readJsonFromSourceUrl(sourceUrl, relativePath);
 
   return {
+    analytics: await readJson(inputSpecs.analytics.file),
     content: await readJson(inputSpecs.content.file),
     oauth2: await readJson(inputSpecs.oauth2.file),
     search: await readJson(inputSpecs.search.file),
@@ -349,6 +356,13 @@ export const generateCatalogs = async (options = {}) => {
   const operationCatalog = createOperationCatalog();
   const publicOperationCatalog = createPublicOperationCatalog();
 
+  addSpecOperations({
+    auth: "app",
+    catalog: operationCatalog,
+    service: inputSpecs.analytics.service,
+    spec: specs.analytics,
+    version: inputSpecs.analytics.version,
+  });
   addSpecOperations({
     auth: "app",
     catalog: operationCatalog,


### PR DESCRIPTION
## Summary

- add the Analytics v1 operation to the generated server catalog while keeping it out of the public/browser catalog
- expose `client.analytics.v1.events.submit(...)` with typed camelCase inputs and responses
- serialize SDK-owned fields to the API snake_case contract without changing caller-defined `properties` keys
- request and cache a client-credentials token with only `analytics.events.write`
- support both the default service URL and configured Gateway routing at `/analytics/v1/events:batch`
- document server-only usage and add a minor Changeset

The catalog path normalizer now converts only segment-leading Express parameters such as `/:id`, so the literal action path `events:batch` remains intact.

## Example

```ts
const result = await client.analytics.v1.events.submit({
  events: [{
    eventId: crypto.randomUUID(),
    name: "quran.reader.verse_viewed",
    version: 1,
    occurredAt: new Date(),
    userId: "QURAN_FOUNDATION_USER_ID",
    properties: { verseKey: "2:255" },
  }],
});
```

## Verification

- `pnpm --filter @quranjs/api check:operation-catalogs`
- `pnpm lint --quiet`
- `pnpm typecheck`
- `pnpm test` (150 tests)
- `pnpm build --filter='./packages/*'`
- `pnpm --filter @quranjs/api size`