### PR TITLE
Expose chapter recitations in Content Sync

### DIFF
--- a/.changeset/tender-radios-sync.md
+++ b/.changeset/tender-radios-sync.md
@@ -1,0 +1,5 @@
+---
+"@quranjs/api": minor
+---
+
+Add `chapter_recitations` to the Content Sync resource-group contract.

--- a/packages/api/src/generated/specs/operation-catalog.json
+++ b/packages/api/src/generated/specs/operation-catalog.json
@@ -829,6 +829,36 @@
           "method": "get",
           "path": "/v1/rooms/{id}/members"
         },
+        "roomsControllerGetClosedGroupJoinRequestStatus": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/rooms/{groupId}/join-request"
+        },
+        "roomsControllerRequestToJoinClosedGroup": {
+          "auth": "user",
+          "method": "post",
+          "path": "/v1/rooms/{groupId}/join-request"
+        },
+        "roomsControllerCancelClosedGroupJoinRequest": {
+          "auth": "user",
+          "method": "delete",
+          "path": "/v1/rooms/{groupId}/join-request"
+        },
+        "roomsControllerGetPendingClosedGroupJoinRequests": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/rooms/{groupId}/join-requests"
+        },
+        "roomsControllerApproveClosedGroupJoinRequest": {
+          "auth": "user",
+          "method": "post",
+          "path": "/v1/rooms/{groupId}/join-requests/{userId}/approve"
+        },
+        "roomsControllerRejectClosedGroupJoinRequest": {
+          "auth": "user",
+          "method": "delete",
+          "path": "/v1/rooms/{groupId}/join-requests/{userId}"
+        },
         "roomsControllerInviteUserToRoom": {
           "auth": "user",
           "method": "post",
@@ -939,6 +969,11 @@
           "method": "get",
           "path": "/v1/posts/my-posts"
         },
+        "postsControllerGetMyPostsCountWithinRange": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/posts/count-within-range"
+        },
         "postsControllerGetLikedState": {
           "auth": "user",
           "method": "get",
@@ -1008,11 +1043,6 @@
           "auth": "user",
           "method": "post",
           "path": "/v1/posts/export/pdf"
-        },
-        "postsControllerGetMyPostsCountWithinRange": {
-          "auth": "user",
-          "method": "get",
-          "path": "/v1/posts/count-within-range"
         },
         "postsControllerGetPublicPostCountByVerse": {
           "auth": "user",

--- a/packages/api/src/generated/specs/public-operation-catalog.json
+++ b/packages/api/src/generated/specs/public-operation-catalog.json
@@ -333,6 +333,36 @@
           "method": "get",
           "path": "/v1/rooms/{id}/members"
         },
+        "roomsControllerGetClosedGroupJoinRequestStatus": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/rooms/{groupId}/join-request"
+        },
+        "roomsControllerRequestToJoinClosedGroup": {
+          "auth": "user",
+          "method": "post",
+          "path": "/v1/rooms/{groupId}/join-request"
+        },
+        "roomsControllerCancelClosedGroupJoinRequest": {
+          "auth": "user",
+          "method": "delete",
+          "path": "/v1/rooms/{groupId}/join-request"
+        },
+        "roomsControllerGetPendingClosedGroupJoinRequests": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/rooms/{groupId}/join-requests"
+        },
+        "roomsControllerApproveClosedGroupJoinRequest": {
+          "auth": "user",
+          "method": "post",
+          "path": "/v1/rooms/{groupId}/join-requests/{userId}/approve"
+        },
+        "roomsControllerRejectClosedGroupJoinRequest": {
+          "auth": "user",
+          "method": "delete",
+          "path": "/v1/rooms/{groupId}/join-requests/{userId}"
+        },
         "roomsControllerInviteUserToRoom": {
           "auth": "user",
           "method": "post",
@@ -443,6 +473,11 @@
           "method": "get",
           "path": "/v1/posts/my-posts"
         },
+        "postsControllerGetMyPostsCountWithinRange": {
+          "auth": "user",
+          "method": "get",
+          "path": "/v1/posts/count-within-range"
+        },
         "postsControllerGetLikedState": {
           "auth": "user",
           "method": "get",
@@ -512,11 +547,6 @@
           "auth": "user",
           "method": "post",
           "path": "/v1/posts/export/pdf"
-        },
-        "postsControllerGetMyPostsCountWithinRange": {
-          "auth": "user",
-          "method": "get",
-          "path": "/v1/posts/count-within-range"
         },
         "postsControllerGetPublicPostCountByVerse": {
           "auth": "user",

--- a/packages/api/src/sdk/resources.ts
+++ b/packages/api/src/sdk/resources.ts
@@ -215,7 +215,7 @@ export class QuranResources {
    * @example
    * client.resources.sync({
    *   bootstrap: true,
-   *   resources: "mushafs:1;translations:19;word_by_word_translations:85"
+   *   resources: "chapter_recitations:159;mushafs:1;translations:19"
    * })
    */
   async sync<TData extends Record<string, unknown> = Record<string, unknown>>(
@@ -233,7 +233,7 @@ export class QuranResources {
    * @param {string | number} id
    * @param {ContentResourceSnapshotOptions} options
    * @example
-   * client.resources.findSnapshot("mushafs", 1)
+   * client.resources.findSnapshot("chapter_recitations", 159)
    */
   async findSnapshot<
     TRecord extends Record<string, unknown> = Record<string, unknown>,

--- a/packages/api/src/types/api/Resources.ts
+++ b/packages/api/src/types/api/Resources.ts
@@ -83,6 +83,7 @@ export interface ChapterReciterResource {
 
 export type ContentSyncResourceGroup =
   | "articles"
+  | "chapter_recitations"
   | "mushafs"
   | "recitations"
   | "tafsirs"
@@ -184,7 +185,7 @@ export type ContentSyncMutationType =
   | "RESOURCE_INVALIDATE";
 
 export interface ContentSyncOptions extends ApiParams {
-  /** Resource filter, e.g. `articles:*;mushafs:1;translations:1,6;word_by_word_translations:85`. */
+  /** Resource filter, e.g. `articles:*;chapter_recitations:159;mushafs:1;translations:1,6`. */
   resources?: string;
   /** Set to true for the initial sync. */
   bootstrap?: boolean;

--- a/packages/api/test/public-types.test.ts
+++ b/packages/api/test/public-types.test.ts
@@ -54,6 +54,7 @@ describe("@quranjs/api/public type surface", () => {
       const client: PublicClient | null = null;
       const resourceGroup: ContentSyncResourceGroup = "word_by_word_translations";
       const mushafResourceGroup: ContentSyncResourceGroup = "mushafs";
+      const chapterResourceGroup: ContentSyncResourceGroup = "chapter_recitations";
       const record: WordByWordTranslationSnapshotRecord = {
         id: 1,
         resourceContentId: 85,
@@ -146,6 +147,7 @@ describe("@quranjs/api/public type surface", () => {
       void client;
       void resourceGroup;
       void mushafResourceGroup;
+      void chapterResourceGroup;
       void genericRecord;
       void nullableRecord;
       void mushafRecords;


### PR DESCRIPTION
## Summary

- expose `chapter_recitations` in the public Content Sync resource-group type
- allow Content Sync requests for chapter-recitation resources
- add public type-surface coverage and a patch changeset

## Related PRs

- API read path and migration: https://github.com/quran/quran.com-api/pull/918
- Tools writer and backfill: https://github.com/quran/tools.quran.com/pull/306
- Python SDK: https://github.com/quran/api-python/pull/9
- Developer docs: https://github.com/quran/qf-api-docs/pull/202

This SDK change can ship independently of the API/tools deployment order.

## Verification

- `npm test`: 150 tests passed across 19 files.
- `npm run lint`: passed; only the existing Node module-type warning was emitted.
- build, typecheck, size, lint, and test CI checks passed.
- `git diff --check origin/main...HEAD` passed.

## Known CI issue

The operation-catalog check detects unrelated upstream OpenAPI drift (new room join-request endpoints and a reordered post-count endpoint). Those generated changes are intentionally excluded from this scoped PR.