### PR TITLE
Add word-by-word transliteration Content Sync support

### DIFF
--- a/.changeset/word-transliterations-sync.md
+++ b/.changeset/word-transliterations-sync.md
@@ -1,0 +1,5 @@
+---
+"@quranjs/api": minor
+---
+
+Add typed Content Sync support for word-by-word transliteration resources.

--- a/apps/docs/content/docs/resources.mdx
+++ b/apps/docs/content/docs/resources.mdx
@@ -88,7 +88,7 @@ for (const record of snapshot.records) {
 
 ### Sync Word-by-Word Translations
 
-Use the resource content ID with the `word_by_word_translations` group. Only approved, shareable, translation-only one-word resources are available; transliterations are excluded.
+Use the resource content ID with the `word_by_word_translations` group. Only approved, shareable, translation-only one-word resources are available. Transliteration resources use the separate `word_by_word_transliterations` group documented below.
 
 ```ts
 import type { WordByWordTranslationSnapshotRecord } from "@quranjs/api";
@@ -116,6 +116,41 @@ Snapshot records are returned in canonical `wordId`, `priority`, and `id` order.
 <auto-type-table
   path="../../../../packages/api/src/types/api/Resources.ts"
   name="WordByWordTranslationSnapshotRecord"
+/>
+
+### Sync Word-by-Word Transliterations
+
+Use the resource content ID with the `word_by_word_transliterations` group for
+approved, shareable, one-word transliteration resources.
+
+```ts
+import type { WordByWordTransliterationSnapshotRecord } from "@quranjs/api";
+
+await client.resources.sync({
+  bootstrap: true,
+  resources: "word_by_word_transliterations:60",
+});
+
+const snapshot =
+  await client.resources.findSnapshot<WordByWordTransliterationSnapshotRecord>(
+    "word_by_word_transliterations",
+    60,
+  );
+
+for (const record of snapshot.records) {
+  console.log(record.wordId, record.text);
+}
+```
+
+Incremental mutations use the `word_transliteration` record type. Snapshot
+records are returned in canonical `wordId` and `id` order, and the SDK
+camel-cases the exact eight-field payload.
+
+### WordByWordTransliterationSnapshotRecord Type
+
+<auto-type-table
+  path="../../../../packages/api/src/types/api/Resources.ts"
+  name="WordByWordTransliterationSnapshotRecord"
 />
 
 ### ContentSyncResponse Type

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -135,6 +135,24 @@ Mushaf snapshots include layout metadata, pages, publicly distributable font
 assets, and words. Store the final `nextSyncToken` and use it with the same
 `resources` filter on subsequent sync calls.
 
+Word-by-word transliterations use their resource content ID and expose a typed,
+camel-cased snapshot payload:
+
+```ts
+import type { WordByWordTransliterationSnapshotRecord } from "@quranjs/api";
+
+await client.resources.sync({
+  bootstrap: true,
+  resources: "word_by_word_transliterations:60",
+});
+
+const transliterations =
+  await client.resources.findSnapshot<WordByWordTransliterationSnapshotRecord>(
+    "word_by_word_transliterations",
+    60,
+  );
+```
+
 ## Links
 
 - [Quran Foundation](https://quran.foundation) — Our mission to make the Quran accessible to everyone

--- a/packages/api/src/sdk/resources.ts
+++ b/packages/api/src/sdk/resources.ts
@@ -215,7 +215,7 @@ export class QuranResources {
    * @example
    * client.resources.sync({
    *   bootstrap: true,
-   *   resources: "chapter_recitations:159;mushafs:1;translations:19"
+   *   resources: "mushafs:1;translations:19;word_by_word_transliterations:60"
    * })
    */
   async sync<TData extends Record<string, unknown> = Record<string, unknown>>(
@@ -233,7 +233,7 @@ export class QuranResources {
    * @param {string | number} id
    * @param {ContentResourceSnapshotOptions} options
    * @example
-   * client.resources.findSnapshot("chapter_recitations", 159)
+   * client.resources.findSnapshot("word_by_word_transliterations", 60)
    */
   async findSnapshot<
     TRecord extends Record<string, unknown> = Record<string, unknown>,

--- a/packages/api/src/types/api/Resources.ts
+++ b/packages/api/src/types/api/Resources.ts
@@ -88,6 +88,7 @@ export type ContentSyncResourceGroup =
   | "recitations"
   | "tafsirs"
   | "translations"
+  | "word_by_word_transliterations"
   | "word_by_word_translations";
 
 export interface MushafMetadataSnapshotRecord extends Record<string, unknown> {
@@ -175,6 +176,18 @@ export interface WordByWordTranslationSnapshotRecord
   updatedAt: string;
 }
 
+export interface WordByWordTransliterationSnapshotRecord
+  extends Record<string, unknown> {
+  id: number;
+  resourceContentId: number;
+  resourceId: number;
+  wordId: number;
+  languageId: number;
+  languageName: string | null;
+  text: string | null;
+  updatedAt: string;
+}
+
 export type ContentSyncMutationType =
   | "RESOURCE_CREATE"
   | "RESOURCE_UPDATE"
@@ -185,7 +198,7 @@ export type ContentSyncMutationType =
   | "RESOURCE_INVALIDATE";
 
 export interface ContentSyncOptions extends ApiParams {
-  /** Resource filter, e.g. `articles:*;chapter_recitations:159;mushafs:1;translations:1,6`. */
+  /** Resource filter, e.g. `articles:*;mushafs:1;translations:1,6;word_by_word_transliterations:60`. */
   resources?: string;
   /** Set to true for the initial sync. */
   bootstrap?: boolean;

--- a/packages/api/test/public-types.test.ts
+++ b/packages/api/test/public-types.test.ts
@@ -41,6 +41,7 @@ describe("@quranjs/api/public type surface", () => {
         MushafPageSnapshotRecord,
         MushafSnapshotRecord,
         MushafWordSnapshotRecord,
+        WordByWordTransliterationSnapshotRecord,
         WordByWordTranslationSnapshotRecord,
       } from "@quranjs/api";
 
@@ -55,6 +56,17 @@ describe("@quranjs/api/public type surface", () => {
       const resourceGroup: ContentSyncResourceGroup = "word_by_word_translations";
       const mushafResourceGroup: ContentSyncResourceGroup = "mushafs";
       const chapterResourceGroup: ContentSyncResourceGroup = "chapter_recitations";
+      const transliterationResourceGroup: ContentSyncResourceGroup = "word_by_word_transliterations";
+      const transliterationRecord: WordByWordTransliterationSnapshotRecord = {
+        id: 1,
+        resourceContentId: 60,
+        resourceId: 60,
+        wordId: 1,
+        languageId: 38,
+        languageName: "english",
+        text: "bis'mi",
+        updatedAt: "2026-08-30T02:43:00Z",
+      };
       const record: WordByWordTranslationSnapshotRecord = {
         id: 1,
         resourceContentId: 85,
@@ -148,6 +160,8 @@ describe("@quranjs/api/public type surface", () => {
       void resourceGroup;
       void mushafResourceGroup;
       void chapterResourceGroup;
+      void transliterationResourceGroup;
+      void transliterationRecord;
       void genericRecord;
       void nullableRecord;
       void mushafRecords;

--- a/packages/api/test/resources.test.ts
+++ b/packages/api/test/resources.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import type {
   MushafSnapshotRecord,
   WordByWordTranslationSnapshotRecord,
+  WordByWordTransliterationSnapshotRecord,
 } from "../src/types";
 import { server } from "../mocks/server";
 import { testClient } from "./test-client";
@@ -199,6 +200,70 @@ describe("Resources API", () => {
       expect(mutation?.data?.verseKey).toBe("26:153");
     });
 
+    it("returns word transliteration mutation metadata and data", async () => {
+      server.use(
+        http.get(
+          "https://apis.quran.foundation/content/api/v4/resources/sync",
+          () =>
+            HttpResponse.json({
+              sync: {
+                sync_until_sequence: 98103,
+                has_more: false,
+                next_page_url: null,
+                next_sync_token: "sync-token-98103",
+                mutations: [
+                  {
+                    sequence: 98103,
+                    type: "ROW_UPDATE",
+                    resource_group: "word_by_word_transliterations",
+                    resource_id: 60,
+                    resource_content_id: 60,
+                    record_type: "word_transliteration",
+                    record_key: "1",
+                    source_record_id: 1,
+                    changed_at: "2026-08-30T02:43:00Z",
+                    data: {
+                      id: 1,
+                      resource_content_id: 60,
+                      resource_id: 60,
+                      word_id: 1,
+                      language_id: 38,
+                      language_name: "english",
+                      text: "bis'mi",
+                      updated_at: "2026-08-30T02:43:00Z",
+                    },
+                    snapshot_url: null,
+                    unavailable_reason: null,
+                  },
+                ],
+              },
+            }),
+        ),
+      );
+
+      const response =
+        await testClient.resources.sync<WordByWordTransliterationSnapshotRecord>(
+          {
+            resources: "word_by_word_transliterations:60",
+            syncToken: "sync-token-98102",
+          },
+        );
+
+      const mutation = response.sync.mutations[0];
+      expect(mutation?.resourceGroup).toBe("word_by_word_transliterations");
+      expect(mutation?.recordType).toBe("word_transliteration");
+      expect(mutation?.data).toEqual({
+        id: 1,
+        resourceContentId: 60,
+        resourceId: 60,
+        wordId: 1,
+        languageId: 38,
+        languageName: "english",
+        text: "bis'mi",
+        updatedAt: "2026-08-30T02:43:00Z",
+      });
+    });
+
     it("exposes sync through content.v4.resources", async () => {
       const response = await testClient.content.v4.resources.sync({
         resources: "translations:19",
@@ -378,6 +443,62 @@ describe("Resources API", () => {
           text: "In",
           priority: 1,
           updatedAt: "2026-08-19T02:43:00Z",
+        },
+      ]);
+    });
+
+    it("returns typed camel-cased word-by-word transliteration records", async () => {
+      let requestUrl: URL | null = null;
+
+      server.use(
+        http.get(
+          "https://apis.quran.foundation/content/api/v4/resources/snapshots/word_by_word_transliterations/:id",
+          ({ request, params }) => {
+            requestUrl = new URL(request.url);
+            return HttpResponse.json({
+              resource_group: "word_by_word_transliterations",
+              resource_id: Number(params.id),
+              resource_content_id: Number(params.id),
+              schema_version: 1,
+              sync_sequence: 98103,
+              records: [
+                {
+                  id: 1,
+                  resource_content_id: 60,
+                  resource_id: 60,
+                  word_id: 1,
+                  language_id: 38,
+                  language_name: "english",
+                  text: "bis'mi",
+                  updated_at: "2026-08-30T02:43:00Z",
+                },
+              ],
+            });
+          },
+        ),
+      );
+
+      const snapshot =
+        await testClient.resources.findSnapshot<WordByWordTransliterationSnapshotRecord>(
+          "word_by_word_transliterations",
+          60,
+        );
+
+      const url = expectCapturedUrl(requestUrl);
+      expect(url.pathname).toBe(
+        "/content/api/v4/resources/snapshots/word_by_word_transliterations/60",
+      );
+      expect(snapshot.resourceGroup).toBe("word_by_word_transliterations");
+      expect(snapshot.records).toEqual([
+        {
+          id: 1,
+          resourceContentId: 60,
+          resourceId: 60,
+          wordId: 1,
+          languageId: 38,
+          languageName: "english",
+          text: "bis'mi",
+          updatedAt: "2026-08-30T02:43:00Z",
         },
       ]);
     });


### PR DESCRIPTION
## Summary

- add `word_by_word_transliterations` to the public Content Sync resource-group contract
- export `WordByWordTransliterationSnapshotRecord` with the exact eight-field payload
- cover `word_transliteration` mutation metadata and snapshot camel-casing
- document sync and snapshot usage
- add a minor changeset for `@quranjs/api`

The existing `sync()` and `findSnapshot()` helpers already support the generic endpoint, so no new generated contract is required.

## Upstream

- quran/quran.com-api#921
- quran/tools.quran.com#309

## Verification

- ESLint passed
- full API test suite: 152 tests passed across 19 files
- API CJS, ESM, and declaration builds passed
- documentation production build passed
- changeset status reports a minor `@quranjs/api` bump
- `git diff --check` passed

## Release note

This PR does not merge or publish a release automatically.